### PR TITLE
add cross-atac to snare norebook

### DIFF
--- a/openproblems/tasks/regulatory_effect_prediction/tests/snare_chrompotential_test_steps.ipynb
+++ b/openproblems/tasks/regulatory_effect_prediction/tests/snare_chrompotential_test_steps.ipynb
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -31,7 +31,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -40,7 +40,7 @@
        "((229429,), (229429, 3))"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -60,7 +60,7 @@
        "((5081, 19322), (5081, 229429))"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -78,7 +78,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,8 +225,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -658,13 +663,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['2410089E03Rik']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['2410089E03Rik']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -1112,13 +1111,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['A230050P20Rik']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['A230050P20Rik']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -1643,13 +1636,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Ccdc109b']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Ccdc109b']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -2321,13 +2308,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Fam213b']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Fam213b']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -2775,13 +2756,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Gm15210']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Gm15210']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -3782,13 +3757,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Gm5453']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Gm5453']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -4334,13 +4303,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['K230010J24Rik']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['K230010J24Rik']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -4732,13 +4695,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Myeov2']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Myeov2']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -5949,13 +5906,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Rnmtl1']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Rnmtl1']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -6438,13 +6389,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Usmg5']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Usmg5']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -7669,13 +7614,7 @@
       "            FROM gene\n",
       "            WHERE gene_name = ?\n",
       "        \n",
-      "with parameters: ['Gm26515']\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
+      "with parameters: ['Gm26515']\n",
       "No results found for query:\n",
       "\n",
       "            SELECT distinct gene_id\n",
@@ -8672,7 +8611,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -8781,7 +8720,7 @@
        "0610009L18Rik      +  "
       ]
      },
-     "execution_count": 11,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8792,7 +8731,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -8801,7 +8740,7 @@
        "((5081, 19322), (5081, 229429))"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8812,7 +8751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8826,7 +8765,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -8835,7 +8774,7 @@
        "((4883, 12940), (4883, 229429))"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8853,7 +8792,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8872,7 +8811,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8883,7 +8822,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 312,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8893,7 +8832,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8906,7 +8845,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -8915,7 +8854,7 @@
        "((4883, 1999), (4883, 229429))"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8933,7 +8872,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -8948,7 +8887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -8957,7 +8896,7 @@
        "((4883, 1999), (4883, 229429))"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -8968,7 +8907,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -9048,7 +8987,7 @@
        "1110019D14Rik   13871526.0   14044385.0      +"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9059,7 +8998,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -9068,7 +9007,7 @@
        "(1999,)"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9083,7 +9022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9104,7 +9043,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -9113,7 +9052,7 @@
        "(1999, 1999)"
       ]
      },
-     "execution_count": 104,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9124,7 +9063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9149,7 +9088,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
@@ -9158,7 +9097,7 @@
        "((229429, 3), (229429, 4))"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9176,7 +9115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9189,18 +9128,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/qq06/anaconda3/envs/openproblem/lib/python3.8/subprocess.py:849: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used\n",
-      "  self.stderr = io.open(errread, 'rb', bufsize)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#tss_to_peaks = y.intersect(x, wb=True, wa=True, loj=False).to_dataframe()\n",
     "tss_to_peaks = x.intersect(y, wb=True, wa=True, loj=True)"
@@ -9208,7 +9138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -9234,7 +9164,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -9425,7 +9355,7 @@
        "[236434 rows x 8 columns]"
       ]
      },
-     "execution_count": 176,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9436,7 +9366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 177,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9448,7 +9378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -9639,7 +9569,7 @@
        "[46475 rows x 8 columns]"
       ]
      },
-     "execution_count": 178,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9650,7 +9580,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 179,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -9659,7 +9589,7 @@
        "(46475, 46475)"
       ]
      },
-     "execution_count": 179,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9670,7 +9600,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 180,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -9679,7 +9609,7 @@
        "((46475, 8), 46475, 46475)"
       ]
      },
-     "execution_count": 180,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9690,7 +9620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 181,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -9700,7 +9630,7 @@
        "       5.8000e-04])"
       ]
      },
-     "execution_count": 181,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9713,7 +9643,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 182,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -9722,7 +9652,7 @@
        "(46475, 8)"
       ]
      },
-     "execution_count": 182,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9740,25 +9670,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 183,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/qq06/anaconda3/envs/openproblem/lib/python3.8/site-packages/pandas/core/indexing.py:1596: SettingWithCopyWarning: \n",
+      "/home/dotto/.local/lib/python3.8/site-packages/pandas/core/indexing.py:1597: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  self.obj[key] = _infer_fill_value(value)\n",
-      "/Users/qq06/anaconda3/envs/openproblem/lib/python3.8/site-packages/pandas/core/indexing.py:1745: SettingWithCopyWarning: \n",
+      "  self.obj[key] = value\n",
+      "/home/dotto/.local/lib/python3.8/site-packages/pandas/core/indexing.py:1676: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
       "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
-      "  isetter(ilocs[0], value)\n"
+      "  self._setitem_single_column(ilocs[0], value, pi)\n"
      ]
     }
    ],
@@ -9770,7 +9700,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 186,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -9779,7 +9709,7 @@
        "10.986122886681098"
       ]
      },
-     "execution_count": 186,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9791,14 +9721,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 187,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "<ipython-input-187-127b6076b46a>:2: SettingWithCopyWarning: \n",
+      "<ipython-input-36-127b6076b46a>:2: SettingWithCopyWarning: \n",
       "A value is trying to be set on a copy of a slice from a DataFrame.\n",
       "Try using .loc[row_indexer,col_indexer] = value instead\n",
       "\n",
@@ -9814,7 +9744,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 188,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -9834,7 +9764,7 @@
        "Name: weight, Length: 46475, dtype: float64"
       ]
      },
-     "execution_count": 188,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9845,7 +9775,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 189,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -9854,7 +9784,7 @@
        "2488"
       ]
      },
-     "execution_count": 189,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9865,7 +9795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 192,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -9874,7 +9804,7 @@
        "46475"
       ]
      },
-     "execution_count": 192,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9885,7 +9815,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 201,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9901,7 +9831,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 196,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -9910,7 +9840,7 @@
        "(1999, 229429)"
       ]
      },
-     "execution_count": 196,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9921,7 +9851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 199,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -9930,7 +9860,7 @@
        "1998"
       ]
      },
-     "execution_count": 199,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9941,7 +9871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 200,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -9950,7 +9880,7 @@
        "229414"
       ]
      },
-     "execution_count": 200,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9961,7 +9891,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 202,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -9970,7 +9900,7 @@
        "(1999, 229429)"
       ]
      },
-     "execution_count": 202,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -9981,7 +9911,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 203,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -9990,7 +9920,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 205,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -10011,7 +9941,7 @@
        "        0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])"
       ]
      },
-     "execution_count": 205,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10022,7 +9952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -10032,7 +9962,7 @@
        "\twith 3216015 stored elements in Compressed Sparse Row format>"
       ]
      },
-     "execution_count": 209,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10043,7 +9973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 213,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
@@ -10056,7 +9986,7 @@
        "    obsm: 'mode2', 'gene_score'"
       ]
      },
-     "execution_count": 213,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10074,7 +10004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10083,7 +10013,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 265,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10092,7 +10022,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 297,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10101,11 +10031,76 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 298,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
     "adata.layers['X_knn'] = adata.obsp['connectivities'].dot(adata.X)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:matplotlib.font_manager:findfont: Font family ['Raleway'] not found. Falling back to DejaVu Sans.\n",
+      "WARNING:matplotlib.font_manager:findfont: Font family ['Lato'] not found. Falling back to DejaVu Sans.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import palantir\n",
+    "from joblib import Parallel, delayed\n",
+    "from scipy.sparse import hstack, csr_matrix, issparse"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Determing nearest neighbor graph...\n"
+     ]
+    }
+   ],
+   "source": [
+    "dm_res = palantir.utils.run_diffusion_maps(pd.DataFrame(adata.obsm['X_pca'], index=adata.obs_names))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_steps = 10 # this is rather high and may be recosidered\n",
+    "T_steps = dm_res['T'] ** n_steps\n",
+    "T_steps = T_steps.astype(np.float32)\n",
+    "def _dot_func(x, y):\n",
+    "    return x.dot(y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = adata.X\n",
+    "seq = np.append(np.arange(0, X.shape[1], 100), [X.shape[1]])\n",
+    "res = Parallel(n_jobs=-1)(delayed(_dot_func)(T_steps, X[:, seq[i - 1]:seq[i]]) for i in range(1, len(seq)))\n",
+    "imputed_data = hstack(res)\n",
+    "imputed_data.data[imputed_data.data < 1e-2] = 0\n",
+    "imputed_data.eliminate_zeros()\n",
+    "adata.layers['X_magic'] = imputed_data"
    ]
   },
   {
@@ -10117,7 +10112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 299,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10125,10 +10120,35 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = adata.obsm[\"gene_score\"]\n",
+    "seq = np.append(np.arange(0, X.shape[1], 100), [X.shape[1]])\n",
+    "res = Parallel(n_jobs=-1)(delayed(_dot_func)(T_steps, X[:, seq[i - 1]:seq[i]]) for i in range(1, len(seq)))\n",
+    "imputed_data = hstack(res)\n",
+    "imputed_data.data[imputed_data.data < 1e-2] = 0\n",
+    "imputed_data.eliminate_zeros()\n",
+    "adata.layers['gene_score_cross_magic'] = imputed_data"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from scipy.stats import pearsonr\n",
+    "import seaborn as sns"
    ]
   },
   {
@@ -10140,20 +10160,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 303,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from scipy.stats import pearsonr\n",
-    "cors = []\n",
-    "for i in range(adata.layers['X_knn'].shape[0]):\n",
-    "    cors.append(pearsonr(adata.layers['X_knn'].toarray()[i],\n",
-    "                         adata.layers['gene_score_knn'].toarray()[i]))"
+    "cors = Parallel(n_jobs=-1)(\n",
+    "    delayed(pearsonr)(\n",
+    "        adata.layers['X_knn'].toarray()[i],\n",
+    "        adata.layers['gene_score_knn'].toarray()[i],\n",
+    "    )\n",
+    "    for i in range(adata.layers['X_knn'].shape[0])\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 304,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [
     {
@@ -10162,20 +10184,26 @@
        "<AxesSubplot:ylabel='Density'>"
       ]
      },
-     "execution_count": 304,
+     "execution_count": 61,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:matplotlib.font_manager:findfont: Font family ['Bitstream Vera Sans'] not found. Falling back to DejaVu Sans.\n",
+      "WARNING:matplotlib.font_manager:findfont: Font family ['Bitstream Vera Sans'] not found. Falling back to DejaVu Sans.\n"
+     ]
+    },
+    {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAX4AAAD4CAYAAADrRI2NAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqIElEQVR4nO3deXxU9b3/8ddnZrKvZA8JkLAHEAUiO2rFBa1bq7Yutdra2kV7u9qr7a+3vdf7uNef9rZ6u1xLrRV7tbVaW5XWBayIKCABZAskQMKSkITsK1nne/+YCQ2YkEkyM2eWz/PxyCOTMydzPodJ3px8v9/z/YoxBqWUUuHDZnUBSiml/EuDXymlwowGv1JKhRkNfqWUCjMa/EopFWYcVhfgibS0NJOXl2d1GUopFVS2b99eZ4xJP3t7UAR/Xl4eRUVFVpehlFJBRUSODrZdm3qUUirMaPArpVSY0eBXSqkwo8GvlFJhRoNfKaXCjAa/UkqFGQ1+pZQKMxr8atScTp3SW6lgFBQ3cKnA0djezcOvHeDdg7XUtHYxIzOBj8/N5u7l+URH2K0uTynlAb3iVx7bdbyJKx/byEs7K5g/aRxfWJ5PfLSDR98o4dIfb2DnsUarS1RKeUCv+JVHTrZ28sVnioiKsPHyvcuZNT7x9HNbyuq5/8Vd3LJ6C4/fcgGr5mRbWKlSajh6xa+G5XQa7ntuJy2dPfz6s4VnhD7A4smp/OWry5g9PpH7ntvJhpKTFlWqlPKEBr8a1mt7q/mgvIEfXTubmVmJg+6TGh/F059fyPTMBL7yvzvYd6LZz1UqpTylwa/OqbfPyX+tK2FaRjw3F044576J0RGs+fxCkmIiuPfZHbR09vipSqXUSGjwq3N6+cMTlNW28+0rZmC3ybD7pydE8bPb5nG88RTfe2mPHypUSo2UBr86p2e2HGV6ZjxXzs70+HsuzEvhGyunsXZ3Fa/vrfZhdUqp0dDgV0M6UN3CruNNfPrCiYgMf7U/0JcvmcKs7ER+8PJemju0yUepQKLBr4b0/LbjRNiFT8zLGfH3RthtPHLTXOrbuvjp+lIfVKeUGi2fBb+IPCUiJ0Vk7yDPfVtEjIik+er4amy6e538eWclV8zKIiUuclSvMScniVsXTuR3W45ysKbVyxUqpUbLl1f8TwOrzt4oIhOAK4BjPjy2GqMtZfU0dfRwwyiu9gf61uXTiY208+9/3e+lypRSY+Wz4DfGbAQaBnnqp8B3AZ3hK4CtK64hJsLOimlj+6MsNT6K+z42lXdKa9laVu+l6pRSY+HXNn4RuR6oNMbs8udx1cgYY1i/v4YV09K8MvHanUvzyEiI4sdvlmCM/n+vlNX8FvwiEgt8D/gXD/e/R0SKRKSotrbWt8WpM+ytbKGquZPLZ3k+hPNcoiPsfG3lNLYdaWTjwTqvvKZSavT8ecU/BcgHdonIESAX2CEiWYPtbIxZbYwpNMYUpqen+7FMtW5/DTaBlQXeCX6ATxdOIDspml++fchrr6mUGh2/Bb8xZo8xJsMYk2eMyQMqgPnGGL3DJ8BsOljL3NzkUY/mGUykw8bdy/PZWt7ADp2+WSlL+XI45++BzcAMEakQkbt9dSzlPW1dveyqaGbZ1FSvv/YtCyeSFBPBExsOe/21lVKe89l8/MaYW4d5Ps9Xx1ajt628gT6nYekU799iER/l4LNLJvHztw9x6GQbUzPivX4MpdTw9M5ddYb3DtUR6bCxYNI4n7z+XUvziHLYWL1Rr/qVsooGvzrD+4frWTBxnM/Wz02Nj+JThRP4885KqppP+eQYSqlz0+BXpzW2d1Nc1cLSKd5v3x/oiysm0+c0rHn/qE+Po5QanAa/Oq1/tM3C/BSfHmdCSiyXz8rk+W3H6Ozp8+mxlFIfpcGvTtt+tBGHTZibm+zzY925JI/Gjh7W7q7y+bGUUmfS4FenbT/ayOycJGIifdO+P9CSKalMzYhnzftHdBoHpfxMg18B0NPnZFdFEwsm+mY0z9lEhM8umcSeymY+PN7kl2MqpVw0+BUAxSda6Oxx+mwY52A+OT+X+CgHz2zWTl6l/EmDXwGuZh7Ar8EfH+Xgxvk5/HV3FbWtXX47rlLhToNfAa4RPTnJMWQlRfv1uHcsyaO7z8kfi4779bhKhTMNfgXA3spmzstJ8vtxp2bEszA/hReKjmsnr1J+osGvaOns4Uh9B+fl+j/4wTVl85H6DraWD7Zgm1LK2zT4FXsrmwHX4uhWuPq8bBKiHPxxmzb3KOUPGvzqdPBb0dQDEBNp59oLxvO3vVW0dPZYUoNS4USDX7GnsoWc5BivLrwyUp8unEBnj5NXPjxhWQ1KhQsNfsXeymbm5CRaWsPc3CRmZiXo6B6l/ECDP8y1dPZQXtduWTNPPxHhU4UT2F3RzP6qFktrUSrUafCHuX2VrpC1qmN3oE/MyyHSbuPF7RVWl6JUSNPgD3NWd+wONC4ukoump7N29wmcTh3Tr5Sv+HKx9adE5KSI7B2w7VEROSAiu0XkzyKS7KvjK8/sqWxmfFI0qfFRVpcCwHUXjKempYsPjuiYfqV8xZdX/E8Dq87atg6YY4yZC5QCD/rw+MoDro5d66/2+11WkEFMhJ1Xd+noHqV8xWfBb4zZCDScte1NY0yv+8stQK6vjq+G19rZQ1kAdOwOFBvp4LJZmby2t5qePqfV5SgVkqxs4/888NpQT4rIPSJSJCJFtbW1fiwrfOw74e7YtWiqhqFcOzebhvZu3jtUZ3UpSoUkS4JfRL4P9ALPDrWPMWa1MabQGFOYnp7uv+LCSCB17A508Yx0EqIdvLpLl2VUyhf8HvwichdwDXC70ekYLbWnspnspGjSAqRjt1+Uw86q2Vm8ua9aF2NXygf8Gvwisgr4LnCdMabDn8dWH7W/qoXZ4629Y3co110wntauXjaUaDOfUt7my+Gcvwc2AzNEpEJE7gZ+DiQA60TkQxF5wlfHV+fW2dPH4dp2ZmYFZvAvmZxKalwkr+3V5h6lvM3hqxc2xtw6yObf+Op4amQOnWyjz2mYmZ1gdSmDcthtfGxmBm/uc43uibDrvYZKeYv+NoWpA9WtABRkB+YVP7jG9Ld09lJ0pNHqUpQKKRr8YepAVQtRDht5qXFWlzKkFdPSibTbeGt/jdWlKBVSNPjD1P7qFmZkJWC3idWlDCkuysGSKams31+j6/Eq5UUa/GHIGMP+qlZmZgVm+/5AlxVkcKS+g8O17VaXolTI0OAPQ7VtXTS0dwd0+36/lQWZANrco5QXafCHoQNVro7dQB3KOdD45BhmZSfy1v6TVpeiVMjQ4A9D/StcBUNTD7iae4qONtDY3m11KUqFBA3+MHSgupWsxGjGWbi4+kisLMjEaeDtEr3qV8obNPjD0P6qloC9cWsw5+UkkZEQxd8PaPAr5Q0a/GGmu9fJ4dq2oOjY7WezCcunpfH+4XpdklEpL9DgDzOHa9vo6TNB077fb/nUNBrauyl2908opUZPgz/MHKh2BWcwXfGDK/gBXZxFKS/Q4A8zB6paibTbyE8L3KkaBpORGM30zHg2afArNWYa/GFmf3UrUzPig3K2y2VT0/igvEEXZ1FqjILvt1+NSUl1S9C17/dbMS2Nrl4n24/qbJ1KjYUGfxhp7uihpqWL6UEa/AvzU3HYRJt7lBojDf4wUnrSNVXDjMzgDP74KAfzJiaz6aAGv1JjocEfRkrci68E6xU/wPKp6ew90azTNyg1Bhr8YaS0ppX4KAfjk6KtLmXUlk9LxRjYXFZvdSlKBS1fLrb+lIicFJG9A7aliMg6ETno/jzOV8dXH1VS3cq0zHhEAnfxleGcn5tMfJSDd7W5R6lR8+UV/9PAqrO2PQC8ZYyZBrzl/lr5gTGG0prWoG3f7+ew21iUn8IWveJXatR8FvzGmI1Aw1mbrwfWuB+vAW7w1fHVmeraumns6GF6kAc/wJIpqZTXtVPd3Gl1KUoFJX+38WcaY6rcj6uBzKF2FJF7RKRIRIpqa2v9U10IK61xj+gJ4o7dfosnpwKwtVyv+pUaDcs6d41r9ewhp1o0xqw2xhQaYwrT09P9WFlo6h/RMy0z3uJKxq4gO5GEaIc29yg1Sv4O/hoRyQZwf9YJ1v2ktKaVcbERpMdHWV3KmNltwqL8FDYf1uBXajT8HfyvAHe6H98JvOzn44et0ppWpmcmBPWInoEWT07lSH0HVc2nrC5FqaDjy+Gcvwc2AzNEpEJE7gYeBi4XkYPAZe6vlY+5RvS0hUT7fr/T7fxlZ48fUEoNx+GrFzbG3DrEUyt9dUw1uBPNnbR19YbEiJ5+BdmJJLrb+W+Yl2N1OUoFFb1zNwyU9k/VEELBb7cJC/NTtYNXqVHQ4A8DJTX9wR/8I3oGWjw5Rdv5lRoFDf4wUFrTSmZiFMmxkVaX4lX97fx61a/UyGjwh4H+ET2hZlZ2IkkxEWw5rB28So2EBn+I63MaDta0Bf0cPYOx2YSF+Sls0Tt4lRoRDf4Qd6yhg65eZ0he8YOruedofQcnmrSdXylPafCHuFBYfOVcFk9OAXTeHqVGQoM/xB10j+iZlhFaI3r6FWS52vl1+galPOdR8IvISyLycRHR/yiCTElNKxNSYoiL8tm9epayueft2aJ38CrlMU+D/JfAbcBBEXlYRGb4sCblRaGw+MpwFk9O5VhDB5Xazq+URzwKfmPMemPM7cB84AiwXkTeF5HPiUiELwtUo9fd66Sstp1pYRD8AFt1PL9SHvG46UZEUoG7gC8AO4HHcf1HsM4nlakxO1LfTq/ThPwV/8ysBNd4fg1+pTziUcOviPwZmAH8Drh2wCpaz4tIka+KU2NTEoJz9AxG2/mVGhlPr/h/bYyZZYz5z/7QF5EoAGNMoc+qU2NSWtOK3SZMTo+zuhSfWzJF2/mV8pSnwf/vg2zb7M1ClPeVVLcyKTWW6Ai71aX43Ol5e3RYp1LDOmdTj4hkATlAjIjMA/qXb0oEYn1cmxqj0ppWCrITrS7DL2ZkJpAc62rnv3FBrtXlKBXQhmvjvxJXh24u8JMB21uB7/moJuUFnT19HG3o4PoLwmORktPt/HoHr1LDOmfwG2PWAGtE5EZjzJ/8VJPygkMn2zCGkFpucTiLJ6fyxr4aKho7yB2nf5AqNZThmno+Y4z5XyBPRL519vPGmJ8M8m0qAITLiJ6Blkz5xzq8uQs0+JUaynCdu/3DQeKBhEE+RkVEviki+0Rkr4j8XkSiR/taanClNa1E2m3kpYZPAE7PSGBcbASbdTy/Uuc0XFPPr9yf/9VbBxSRHOCfgFnGmFMi8kfgFuBpbx1DuebomZweh8MePtMrudr5dR1epYbj6SRtj4hIoohEiMhbIlIrIp8Zw3EduEYKOXCNDjoxhtdSgzhY0xZWzTz9Fk9OoaLxFMcbOqwuRamA5enl4BXGmBbgGlxz9UwF7h/NAY0xlcCPgWNAFdBsjHnz7P1E5B4RKRKRotra2tEcKmy1dvZQ2XQqrDp2+y2Zkgag0zQrdQ6eBn9/k9DHgReMMc2jPaCIjAOuB/KB8UDcYH89GGNWG2MKjTGF6enpoz1cWCqtaQMI+Tl6BjM9M56MhCjeOagXC0oNxdPgXysiB4AFwFsikg50jvKYlwHlxphaY0wP8BKwdJSvpQZR6l58JRyv+EWEi6ans+lgHX1OY3U5SgUkT6dlfgBXOBe6w7od11X7aBwDFotIrIgIsBLYP8rXUoMoqW4lNtJOTnKM1aVY4qLp6TSf6mFXRZPVpSgVkEayLNNMXOP5B37PMyM9oDFmq4i8COwAenFN8bx6pK+jhlZa08q0zARsNhl+5xC0YmoaIrCxtJb5E8dZXY5SAcfTUT2/w9Uhuxy40P0x6lk5jTE/NMbMNMbMMcbcYYzpGu1rqY9yrboVmmvsemJcXCRzc5N5p1Tb+ZUajKdX/IW4xt1ro2mAq2vroq6tOyyHcg70sRnpPP7WQeraukiLj7K6HKUCiqedu3uBLF8WorwjnDt2B7qsIBNj4O0DJ60uRamA4+kVfxpQLCIfAKebZYwx1/mkKjVqpe45esJxKOdAs8cnkpUYzVv7T3Jz4QSry1EqoHga/D/yZRHKe0pq2kiOjSA9IbybN0SESwsyeHlnJV29fUQ5Qn8xGqU85elwzndw3bEb4X68DdeoHBVgSmtamZ6ZgGukbHi7vCCT9u4+vYtXqbN4Oqrni8CLwK/cm3KAv/ioJjVKxhhKq1vDvpmn35IpqcRF2nljX7XVpSgVUDzt3L0XWAa0ABhjDgIZvipKjU5VcyetXb1MD/OO3X7REXZWFmTyxr4aevucVpejVMDwNPi7jDHd/V+4b+LSoZ0BpqRGO3bPdvV52TS0d7OlrMHqUpQKGJ4G/zsi8j1cUylfDrwAvOq7stRolJ5edSt8b9462yUz0omLtPPXPVVWl6JUwPA0+B8AaoE9wJeAvwH/z1dFqdEpqWklMzGK5NhIq0sJGNERdi4tyOT1vVX0aHOPUoDno3qcuDpzv2qMuckY82u9izfw9I/oUWe64YLxNHb08E6JTuGgFAwT/OLyIxGpA0qAEvfqW//in/KUp/qchoM1bdq+P4iLpqeTGhfJSzsrrC5FqYAw3BX/N3GN5rnQGJNijEkBFgHLROSbPq9OeexYQwddvU4d0TOICLuN6y4Yz/rikzR39FhdjlKWGy747wBuNcaU928wxpQBnwE+68vC1MiU6FQN53Tj/Fy6+5y8uluXd1ZquOCPMMbUnb3RGFMLRPimJDUa/ZOzTdMRPYOaPT6RguxEfv/BMbR7SoW74YK/e5TPKT8rqWllYkossZEjWVsnfIgIty+ayL4TLeyqGPWS0UqFhOGC/3wRaRnkoxU4zx8FKs+UVuuInuHcMC+HuEg7z245anUpSlnqnMFvjLEbYxIH+UgwxmhTT4Do6u2jvK6dGVnazHMu8VEOrp+Xwyu7TlDfpou+qfDl6Q1cXiUiySLyoogcEJH9IrLEijpCRXldO71Oo1f8Hvj8sjy6ep2s2axX/Sp8WRL8wOPA68aYmcD5wH6L6ggJp0f06FDOYU3NSOCygkye2XyEju5eq8tRyhJ+D34RSQIuAn4DYIzpNsY0+buOUHKguhWHTZicpk09nvjKJZNp6ujh+W3HrS5FKUtYccWfj2ven9+KyE4ReVJE4iyoI2Tsr2phakY8kQ6r/oALLgsmpVA4aRxPvluu8/eosGRFUjiA+cD/GGPmAe24JoE7g4jcIyJFIlJUW6tzrJxL8YkWZo1PtLqMoPLli6dQ2XSKtXpDlwpDVgR/BVBhjNnq/vpFXP8RnMEYs9oYU2iMKUxPT/drgcGkrq2Lk61dzMrW4B+JS2dmMC0jnl+9U6Y3dKmw4/fgN8ZUA8dFZIZ700qg2N91hIr9VS0AGvwjZLMJX754CgeqW3ltry7NqMKLVY3CXwOeFZHdwAXAf1hUR9DrD/4CDf4Ru2FeDlMz4vnxmyW6NKMKK5YEvzHmQ3czzlxjzA3GmEYr6ggFxSdayE6KZlycLr4yUnab8J0rplNW285LOyqtLkcpv9FhIEFuf1WrXu2PwZWzszg/N4nH1pfS2dNndTlK+YUGfxDr7OnjUG2btu+PgYhw/5UzOdHcyXNbj1ldjlJ+ocEfxA6dbKPPafSKf4yWT0tj6ZRUfvH2IVo7daEWFfo0+INY8Qn3iB4dwz9m/7xqJvXt3fxyw2GrS1HK5zT4g1hxVQuxkXYmpcRaXUrQO39CMp+cn8Nv3i3nWH2H1eUo5VMa/EGsuKqFmVkJ2GxidSkh4btXzsRuE/7zNZ0zUIU2Df4gZYxhf1WLtu97UVZSNF+5ZAqv7a1mS1m91eUo5TMa/EGqovEUrZ29Gvxeds9FkxmfFM2/vVpMn1OnclChSYM/SJ2eqkE7dr0qOsLOA1cXUFzVwovbddpmFZo0+INUcVULIjBTF1/xumvnZrNg0jgefaNEh3eqkKTBH6R2VzQzNT2e2EiH1aWEHBHhX66ZRV1bNz9/+5DV5SjldRr8QcgYw+6KJubmJltdSsg6f0IyN87P5alN5Rw62WZ1OUp5lQZ/EKpsOkVdWzcXTEiyupSQ9sBVM4mOsPOjV/bpnP0qpGjwB6HdFc0AesXvY+kJUXznihlsOlSnc/arkKLBH4R2HW8i0m5jZrZ27Pra7YsmMis7kYfWFtPe1Wt1OUp5hQZ/ENpV0URBdgJRDrvVpYQ8h93GQzfMpqq5k5/9XTt6VWjQ4A8yfU7D3soWbebxowWTUrhpQS6/2VSmHb0qJGjwB5my2jbauno5f0Ky1aWEFe3oVaFEgz/I7HJ37J6fqyN6/CktPor7r3R19L6y64TV5Sg1JpYFv4jYRWSniKy1qoZgtOt4E/FRDianx1tdSti5fdEkLpiQzL++Wkx9W5fV5Sg1alZe8X8d0PlvR2h3RRNzchKx61TMfme3CY/cNJe2zl5++Mo+q8tRatQsCX4RyQU+DjxpxfGDVVdvH8VVLdq+b6HpmQl87dKprN1dxes6tl8FKauu+B8Dvgs4h9pBRO4RkSIRKaqtrfVbYYHsQFUrPX2G83VEj6W+fMkUZmUn8oOX99LU0W11OUqNmN+DX0SuAU4aY7afaz9jzGpjTKExpjA9Pd1P1QW2XRVNAHrFb7EIu41HbppLY3s397+4W0f5qKBjxRX/MuA6ETkC/AG4VET+14I6gs6Hx5pIi49ifFK01aWEvTk5STx4dQHrimt48t1yq8tRakT8HvzGmAeNMbnGmDzgFuDvxpjP+LuOYLTtaAOFk8Yhoh27geDzy/JYNTuLh18/QNGRBqvLUcpjOo4/SFQ3d3K84RSFeeOsLkW5iQiP3DyX3HEx3PfcTup0iKcKEpYGvzFmgzHmGitrCBZFR11XlAvzUyyuRA2UGB3BL2+fT2NHN19YU8Sp7j6rS1JqWHrFHySKjjQSG2lnli6uHnBmj0/i8Vvmsauiifue20F375CD1ZQKCBr8QWLbkQbmTUzGYde3LBCtmpPFQ9fP4a0DJ/nS74ro7NErfxW4NEWCQGtnD/urWiicpM08gewziyfxH584jw2ltdy9Zhsd3Tp/vwpMGvxBoOhII04Di7R9P+Ddtmgi/3Xz+Ww+XM9nf/OBzumjApIGfxB4/3AdkQ4b8yfpiJ5g8Mn5ufz8tvnsqWzmup+/R/GJFqtLUuoMGvxBYHNZPfMnJhMdoStuBYurz8vmhS8voc9puPF/3uevu6usLkmp0zT4A1xTRzf7TrSwdEqa1aWoEZqbm8wrX1tGQXYC9z63gx++vFc7fVVA0OAPcFvKGjAGlkxJtboUNQoZCdH8/p7F3L08nzWbj/KJX76vyzcqy2nwB7jNh+uIibDrjJxBLMph5wfXzOKpuwqpaenk2p9t4rfvleN06uRuyhoa/AHu3YN1LMxPIdKhb1Wwu3RmJq99fQWLJqfwr68Wc8vqLZTXtVtdlgpDmiYB7Fh9B2V17VwyQ6elDhWZidH89q4L+fHN53OguoVVj23k8fUHte1f+ZUGfwB756BrAZqLp2vwhxIR4aYFuaz71sVcNiuTn64v5bKfvMMb+6p1bn/lFxr8AeydklompMSQnxZndSnKBzITo/nFbfN57ouLiIt08KXfbefWX29hT0Wz1aWpEKfBH6C6e51sPlzHxdPTdf79ELd0Shp//aflPHT9bA7WtHHtzzfxzec/pLLplNWlqRClwR+gPihvoL27j4unZ1hdivIDh93GHUvy2HD/Jdz7sSn8bU8VH/vxBh5+7QAtnT1Wl6dCjAZ/gFpXXE10hI3lU/XGrXCSEB3B/VfO5O3vXMI1c7P51cbDXPzI2zz9XrlO96y8RoM/ABljWFdcw4pp6cRE6jQN4Wh8cgw/+dQFvHrfcgqyE/nRq8WsenwjW8vqrS5NhQAN/gC070QLJ5o7uXxWptWlKIvNyUni2S8s4qm7Cunpc/Lp1Vt48KXdNJ/S5h81ehr8AejN4hpsAitnavu+cg3/vHRmJm984yLuuWgyz287zmU/eYe/7anS4Z9qVPwe/CIyQUTeFpFiEdknIl/3dw2B7vW9VRROSiE1PsrqUlQAiY108L2rC3jlvuVkJETx1Wd38NVnd9DQ3m11aSrIWHHF3wt82xgzC1gM3CsisyyoIyCVVLdSWtPGtednW12KClBzcpJ4+d5l/POqmazfX8OVj23k7QMnrS5LBRG/B78xpsoYs8P9uBXYD+T4u45AtXb3CWwCq+Zo8KuhOew2vnLJFF6+dzmpcZF87ultfO/Pe2jv0uUe1fAsbeMXkTxgHrB1kOfuEZEiESmqra31e21WMMbw6q4TLJ2SRnqCNvOo4c0an8jL9y3jSxdN5vcfHOPq/36X7UcbrS5LBTjLgl9E4oE/Ad8wxnxkbTpjzGpjTKExpjA9PTzmqtlT2cyR+g6umatX+8pzUQ47D15dwB++uJjePsPNT7zPo28c0HH/akiWBL+IROAK/WeNMS9ZUUMgeqGogiiHjavO0+BXI7dociqvf2MFN87P5RdvH+YTv3yPgzWtVpelApAVo3oE+A2w3xjzE38fP1B19vTx8oeVrJqTRVJMhNXlqCCVEB3Bozefz6/uWEBVcycf/9kmntqki76oM1lxxb8MuAO4VEQ+dH9cbUEdAeXN4hpaOnv5VOEEq0tRIeDK2Vm88Y2LWDE1jX9bW8wdT23lhE76ptysGNWzyRgjxpi5xpgL3B9/83cdgeb5bcfISY5hyWRdW1d5R3pCFE/eWcjDnzyPnceauPKxjby0o0Jv+lJ6524gOHSylfcO1XPrwgnYbDoFs/IeEeGWhRN57esrmJ6ZwLf+uIvPPb2NisYOq0tTFtLgDwBr3j9KpMPGrQsnWl2KClGTUuP445eW8KNrZ/FBeQNX/HQjv32vnD5t+w9LGvwWa+ns4U87Krh27nidokH5lN0m3LUsnze/eREX5rkWfL/pifcpPvGR0dQqxGnwW+y5rcfo6O7jrqV5VpeiwkTuuFie/tyFPPbpCzha38E1P3uXH72yT2f8DCMa/BY61d3Hk++WsWJaGuflJlldjgojIsIN83L4+7cv5vZFk3hm8xFW/tcGXtxeoUM/w4AGv4X+sO0YdW3dfO3SaVaXosJUcmwkD90wh1fuW87ElFi+88IubnzifV3wJcRp8Fuko7uX/9lwmIV5KSzMT7G6HBXm5uQk8eKXl/LoTXOpaurk06u3cNdvP2BvZbPVpSkf0OC3yJPvlnOytYt/vmqG1aUoBYDNJtxcOIEN91/Cg1fNZOexJq752SY+9cRm1u4+QU+fzv0TKhxWFxCOTrZ28sQ7h7lqThYLJunVvgos0RF2vnTxFG5ZOJEXio7zzOaj3PfcTlLjIvnYzAxWzsxg+bQ0EqJ1apFgpcFvgYfW7qe3z/DdVTOtLkWpISXFRPCFFZP53LJ8NpSc5C8fnuDNfdW8uL0Cu02YMz6RC/NSuDA/hQvzUkiJi7S6ZOUhDX4/e2t/Da/uOsG3Lp9Oflqc1eUoNSy7TVhZkMnKgkx6+5xsP9rIxoO1bCtv5JktR3lyUzkA0zLiWTQ5hVWzs1k8OQWHXVuSA5UEw7wdhYWFpqioyOoyxqyhvZurH3+XxBgHa7+2gkiH/mKo4NbZ08eeymY+KG/gg/IGth1poKO7j7T4SK6ak81tiyZSkJ1odZlhS0S2G2MKP7Jdg98/nE7D59ds4/1D9bz01aXMydFx+yr0dPb08faBk6zdXcX6/TV09TpZlJ/CXUvzuHxWpv4V4GdDBb829fjJY+tL2VBSy0M3zNHQVyErOsLOVedlc9V52TR1dPP8tuP8bstRvvLsDiakxPC5pfl86sIJxEdp9FhJr/j94NmtR/n+n/fy6cIJPHzjebjWolEqPPQ5Dev31/Dku2VsO9JIQrSD2xZN5M4leYxPjrG6vJCmTT0WeWbzEX74yj4umZ7Orz9bqH/qqrD24fEmfv1uGa/tqQJg+bR0blqQyxWzMomOsFtcXejR4Peznj4nj75RwuqNZVxWkMnPb5unP9hKuR1v6OCFouP8aUcllU2niImws2hyCsunprFkSipT0uP198ULNPj96EB1Cw++tIedx5q4Y/EkfnjtLL3SV2oQTqdhc1k9b+yrZtPBOsrq2gGwCUxMiSU/LY7U+ChS4yIZFxdJSmwkybERJMVEkOT+nBwTSXSETZtQB6Gdu35wuLaN1e+U8eKOChKjHfz3rfO47vzxVpelVMCy2YRlU9NYNjUNgIrGDrYfbeTwyTYO1bZxpK6DA9Wt1Ld309079JQRkXYbiTERJMU4SIqJICUuktS4KNISXJ9T4yNJi48iLd71OCU2MqxXu7Mk+EVkFfA4YAeeNMY8bEUdY9Xd66S0ppXNh+t5fV812482EuWwccfiSXzjsmkkx+qdjEqNRO64WHLHxX5kuzGGju4+Gtq7aT7VQ1NHD82n/vHRdKqblgFfVzZ1sruimfr27kFXGYuwC5mJ0WQlRpOVFE12UjRZSTHuz66v0+OjQvYvdb8Hv4jYgV8AlwMVwDYRecUYU+yP4xtjMAb6jMFpDE4nOI1xfe009DoNp7r7aO/upb2rj/auXjq6e2nt7KWurZuTrZ3UtHRysKaN8rp2et0/VDOzEvjuqhncvGAC6Qm6kpZS3iQixEU5iItyMGEE3+d0GppP9VDf3kVdWzf1bd3UtnZS09pFdXMnVc2n2FvZzLpi1z0HA9kEMhL+8R9BRkIUMZEOohw2oiJsRDnsrscOG1ERdiLtNiIdgsNmw2EXIu02HHYbEXYhwm7DYXN9jnBvc9ht7n0Eh0382lRlxRX/QuCQMaYMQET+AFwPeD34H1pbzLNbj+I0rh8ApzGMdY2JuEg7GYnRTEmP54rZmUzPTGBhfgrZSTosTalAY7MJ49z9A1Mzht7PGENTRw9VzZ1Ut5xyfW7uPP25tKaVTYfq6Opx0u2jWUoj7ILNHf4iIAgi8Ks7FrBiWrpXj2VF8OcAxwd8XQEsOnsnEbkHuMf9ZZuIlAzxemlAnVcrHEYxsMGfB/wHv5+rhfRcQ5Oe6whd9NCYvn3SYBsDtnPXGLMaWD3cfiJSNFivdSjScw1Neq6hKZDP1Yqei0o4o5ku171NKaWUH1gR/NuAaSKSLyKRwC3AKxbUoZRSYcnvTT3GmF4RuQ94A9dwzqeMMfvG8JLDNgeFED3X0KTnGpoC9lyD4s5dpZRS3hOadycopZQakga/UkqFmaAIfhFJEZF1InLQ/XncEPvd6d7noIjcOWD7BhEpEZEP3R/nuJXDGiKyyl3jIRF5YJDno0TkeffzW0Ukb8BzD7q3l4jIlX4tfBRGe64ikicipwa8j0/4vfgR8uBcLxKRHSLSKyI3nfXcoD/PgWqM59o34H0N+MEeHpzrt0SkWER2i8hbIjJpwHPWv6+uKQwC+wN4BHjA/fgB4P8Psk8KUOb+PM79eJz7uQ1AodXncY7zswOHgclAJLALmHXWPl8FnnA/vgV43v14lnv/KCDf/Tp2q8/JR+eaB+y1+hy8fK55wFzgGeCmAduH/HkOxI+xnKv7uTarz8HL5/oxINb9+CsDfoYD4n0Niit+XFM6rHE/XgPcMMg+VwLrjDENxphGYB2wyj/ljdnpaSyMMd1A/zQWAw38N3gRWCmuyT2uB/5gjOkyxpQDh9yvF6jGcq7BZthzNcYcMcbsBs6eByDYfp7Hcq7BxpNzfdsY0+H+cguu+5UgQN7XYAn+TGNMlftxNZA5yD6DTQWRM+Dr37r/jPxBAIbIcLWfsY8xphdoBlI9/N5AMpZzBcgXkZ0i8o6IrPB1sWM0lvcmFN/Xc4kWkSIR2SIiN3i1Mu8b6bneDbw2yu/1iYCZskFE1gNZgzz1/YFfGGOMiIx0DOrtxphKEUkA/gTcgevPTRVcqoCJxph6EVkA/EVEZhtjWqwuTI3ZJPfv6GTg7yKyxxhz2OqixkpEPgMUAhdbXctAAXPFb4y5zBgzZ5CPl4EaEckGcH8+OchLDDkVhDGm/3Mr8ByB1xTiyTQWp/cREQeQBNR7+L2BZNTn6m7OqgcwxmzH1c463ecVj95Y3ptQfF+HNOB3tAxXn9w8bxbnZR6dq4hchuvC9TpjTNdIvtfnrO4o8bAz5VHO7Nx9ZJB9UoByXB0m49yPU3D9VZPm3icCV5vxl60+p7Nqd+Dq5MnnH51Fs8/a517O7PD8o/vxbM7s3C0jsDt3x3Ku6f3nhqtjrRJIsfqcxnKuA/Z9mo927n7k59nqc/LRuY4DotyP04CDnNVZGkgfHv4Mz8N1YTLtrO0B8b5a/o/o4T90KvCW+wdiff8/FK4/oZ4csN/ncXVuHgI+594WB2wHdgP7cK/8ZfU5DXKOVwOl7h+W77u3/RuuqwWAaOAF97l9AEwe8L3fd39fCXCV1efiq3MFbnS/hx8CO4BrrT4XL5zrhbjaedtx/QW371w/z4H8MdpzBZYCe9wBuge42+pz8cK5rgdq3D+rHwKvBNL7qlM2KKVUmAmYNn6llFL+ocGvlFJhRoNfKaXCjAa/UkqFGQ1+pZQKMxr8SikVZjT4lVIqzPwfuenVbQHoJYIAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD9CAYAAACm2+DgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAygUlEQVR4nO3deXhTVf4/8HeSpvu+7wtdUrpvUHYoIqDWBRgRK4wLIqDUUXABRsZl9KssClIU/Q3qyAiiOAKyiKjAyN6yQ0sL3fd9SdI2aZrc3x+1lUoKSZvk3iSf1/Pkoc29vXmf0vaTe8695/AYhmFACCGE/Amf7QCEEEK4iQoEIYQQtahAEEIIUYsKBCGEELWoQBBCCFGLCgQhhBC1LNgOoEsikYjtCIQQYnQKCgrUPm9SBQIYuKGEEEJudbs31tTFRAghRC0qEIQQQtSiAkEIIUQtKhCEEELUogJBCCFELSoQhBBC1KICQQghRC0qEERvGIZBfUsHxO1dbEchhAyCyd0oR9jHMAwOnirF9p8K0CqVAwACvOwx+64ITEj0B5/PYzkhIUQTVCCITqlUDN7fdg5n8+vwZHo0UoZ7oVPejVNXarD5+8v49WwFXv3rCNjbCNmOSgi5A+piIjq189fruHC9HutfnIjpo4Ph7myDAC8HzJ4SgY9fmQxppwIvb/wNzWIZ21EJIXdABYLoTG5xE74+VICX5qbA193+lu1uTjZ499mxcHeywev/7xSknQoWUhJCNEUFgugEwzD4cn8epqYGIUnkOeB+1pYWWPnkSAgt+Fj9ZQ6UKsaAKQkh2qACQXTiXH49iipb8cjdEXfc18bKAn9/ciRKa8T49meafZcQrqICQXRi20/5uG/cMLg52Wi0v5uTDV56LBnf/HIducVNek5HCBkMKhBkyAorW1Fc2Yr7xw3T6uviIzxw37gQZH17AXKFUk/pCCGDRQWCDNnPZ8qQKPKEh4tmZw83mzd9OJQqBjsOUVcTIVxj0AKxf/9+ZGRkICkp6barGF29ehXR0dGYN2+eAdORwZArlPjf+UpMTQ0a1NdbW1lg8cx47P5fIaobpDpORwgZCoMWCEdHR2RkZGDlypUD7iOXy7FixQqMGDHCgMnIYGVfrYWFBR8jorwHfYykSE8kibzw+d5cHSYjhAyVQQvE+PHjkZ6ejoCAgAH3Wb9+PUaNGoXk5GQDJiODdepqDUbF+EBoMbQfpfkPRONcfh0uFzboKBkhZKg4NQaRk5ODI0eOYOnSpWxHIRpQdKtwLr8OqdGDP3vo5ethj2mjgvGfA9fAMHRvBCFcwJkC0d7ejpUrV+Ltt9+Gjc2dBzuzsrIgEon6PYhhXSlqhErFID7cQyfHmz0lAsXVYuRcq9PJ8QghQ8OZArF69WpMnDhR47GHzMxMFBQU9HsQwzpztQaJIk9YCgU6OZ6rozXSx4Zg28F8OosghAM4M5vr8ePHIRaLsXfvXgCATCZDd3c3UlNT8d1339123IIYHsMwyLlWh8emRer0uA9NCsXe48W4eL0BibeZsoMQon8GLRBKpRLd3d1QKHomaZPLe9YKEAqF+Oabb6BU/nGz1BdffIGLFy/iww8/hIeHbrowiO7UNLajoaVT53/EXRysMWVEIL47fIMKBCEsM2gX0549exAXF4f58+cDAOLi4hAXF4ecnBx4eHjA29u772Fvbw9LS0t4e3tDINBNFwbRnUuFjQjwsoero7XOjz1jUhiuFjXienmLzo9NCNEcjzGhzl6RSERjEQby3tYcONtbYdHMOL0cf81/zkKpUmHF4yP1cnxCSI/b/d3kzCA1MR4qFYMrhY2ID3fX22vMSgvD6Ss1qKK7qwlhDRUIorWyWjEkHV2ICdVfgQj1d0Z8uAe+P1Kot9cghNweFQiitSuFjQjxdYKDraVeX2fGpDAcOVcBcXuXXl+HEKIeFQiitWulzYgKcdX76yREeMDTxRY/nynT+2sRQm5FBYJohWEYXCttxvBg/RcIHo+H9HEhOHCyhJYmJYQFVCCIVhpaO9HUJsPwYDeDvN7klABIOrpwNq/WIK9HCPkDFQiilfzSZrg7WQ9qcaDBsLUWYnJKIPadKDHI6xFC/kAFgmjlWmkzIg3QvXSz+8aG4NKNBlTUSQz6uoSYOyoQRCv5Bhp/uFmAlwPiwtxx4CSdRRBiSFQgiMbkCiWKq8UQBbkY/LXvGxuCw2crIOvqNvhrE2KuqEAQjZVWtwEAgn2dDP7aI6K8YSkU4OTlGoO/NiHmigoE0VhhZRsCvRxgpaP1H7RhIeBjcnIAfs6meyIIMRQqEERjRZWtCPN3Zu31p4wMxNWiJlQ30vxMhBgCFQiiscLKVoT5G757qVeAlwOGB7vil+xy1jIQYk6oQBCNdCmUKK+VIDTAmdUcU1MD8WtOOZRKFas5CDEHVCCIRkprxGAAhLAwQH2zsfF+6JR341xBPas5CDEHVCCIRgorW1kboL6ZjZUFxsX70QR+hBgAFQiikcKKVoSyOP5ws7tHBiEnrw6SDpoGnBB9MmiB2L9/PzIyMpCUlASRSNRv28WLF/HMM89gzJgxSEpKwowZM3Do0CFDxiO3UVTZxuoVTDeLDHaBm5M1Tl6uZjsKISbNoAXC0dERGRkZWLly5S3b2tracO+992Lfvn04e/YsFi1ahGXLluHy5cuGjEjU6FIoUVYr5kyB4PF4GJ/gh98uVLEdhRCTZtACMX78eKSnpyMgIOCWbRMnTsRDDz0EV1dX8Pl8TJs2DeHh4Th37pwhIxI1egeog30d2Y7SZ0KiP64UNaJZLGM7CiEmi7NjEHV1dSguLkZkZCTbUcxe0e8D1NaWFmxH6RPi6whfd3scv0RnEYToCycLRHt7OzIzM5GWlobRo0er3ScrKwsikajfg+hHYWUbZwaoe/F4PExMpG4mQvSJcwVCIpHg6aefhoeHB1avXj3gfpmZmSgoKOj3IPpRyPIUGwMZn+iHgrIW1Da1sx2FEJPEqQLR0tKCxx9/HD4+Pvjwww9haWnJdiSzp+hWobxWjFA/Z7aj3MLf0wHD/Jxw/BJdzUSIPhi0QCiVSsjlcigUCgCAXC6HXC6HSqVCQ0MD5s2bB5FIhHXr1sHCgjv93eassl6CbiXDqQHqm01I8MNvFyrZjkGISTLoX+E9e/ZgxYoVfZ/HxcUBALZu3YqcnBzcuHEDlZWVOHjwYN8+999/P9566y1DxiQ3KakWw8fNDjZW3CzYY+N98e/9eahtaoe3mx3bcQgxKQb9rZ85cyZmzpypdltqaiqWLFliyDhEA6U1Ys6ePQCAt5sdgrwdkJ1biwcmhLIdhxCTwqkxCMI9pdVtCPHhboEAgJHR3sjOq2U7BiEmhwoEuS2un0EAwMgob1wtakJ7p4LtKISYFCoQZECtEjlaJHIE+3DrHog/Cw90gYOtJc7TFOCE6BQVCDKg0po2WFsK4OVqy3aU2xLweUgZ7oXsXOpmIkSXqECQAZXWiBHk4wg+n8d2lDsaGe2Fs9fqaKU5QnSICgQZUEm1mPUV5DSVEOEJuUKJa6XNbEchxGRQgSADKq0RI5jjVzD1srGyQFyYO7Lz6tiOQojJoAJB1OpWqlBeKzGaAgH8frkrjUMQojNUIIhaVQ1SdCtVRlUgRgz3RlWDlCbvI0RHqEAQtUqrxfB0sYGdjZDtKBrzcLGBn4c9Ll5vYDsKISaBCgRRq7TGeAaob5YQ4YGLN6hAEKILVCCIWiXVbUbVvdQrIcIDl280QKVi2I5CiNGjAkHUMoYpNtSJDXVHe6cCxVVtbEchxOhRgSC3kHR0oalNhiBv4ysQdjZChAe6UDcTITpABYLcoqxGDKEFH77uxrm+QkKEBy7RQDUhQ0YFgtyivE6CAE8HCATG+eOREO6B3JImyBVKtqMQYtSM8y8A0auyGjECfRzYjjFooiBXCPg8XCtpYjsKIUaNCgS5RVmtxCjHH3oJLfiICXWn+yEIGSKDFoj9+/cjIyMDSUlJEIlEt2zPy8vDnDlzEB8fj0mTJmHr1q2GjEcAMAyD8loxAr2N9wwCAOLD6X4IQobKoAXC0dERGRkZWLly5S3bpFIpnn76aYwbNw7Z2dnYsGEDNm3ahIMHDxoyotlrlcgh6VAY9RkE0DNQXVzVBnF7F9tRCDFaBi0Q48ePR3p6OgICAm7ZdujQIfD5fDz77LOwsrJCQkICHn74YWzfvt2QEc1eWa0YNlYCeDjbsB1lSIK8HeBga4nc4ka2oxBitDgzBpGfn4+oqCjw+X9EiomJQX5+PoupzE9ZrQSBXsaxSNDt8Hg8xIa643IhFQhCBsuC7QC9pFIpHBz693s7OjpCKpWq3T8rKwubNm0yRDSzUlZj/OMPvWJD3XDwdBnbMQgxWpw5g7C3t7+lGIjFYtjb26vdPzMzEwUFBf0eZOjKayUINPLxh14xYe4orRGjTSpnOwohRokzBSIyMhJ5eXlQqf5YUzg3NxeRkZEspjIvDMOgvE6MIBM5gwj0coCTvSVyi+l+CEIGw6AFQqlUQi6XQ6FQAADkcjnkcjlUKhWmTp0KpVKJzZs3o6urC5cvX8bOnTvx6KOPGjKiWWto6USnXIkgI5zFVR0ej4eYUHdcKaJxCEIGw6AFYs+ePYiLi8P8+fMBAHFxcYiLi0NOTg7s7e2xZcsW/Pbbb0hJSUFmZiaee+453HPPPYaMaNbKasVwsBXCxcGK7Sg6Exvqjis0UE3IoGg1SH3u3DkkJycP+sVmzpyJmTNnDrg9KioK33zzzaCPT4am7PfxBx7PuK9gullsqBs++f4y2qRyONmbTuEjxBC0OoOYO3cu0tPTsXXrVrS10Xz7pqbMBO6g/rMALwc421vhKo1DEKI1rQrEzz//jClTpuCzzz7DhAkT8NJLLyEnJ0df2YiBlRv5HEzq9IxDuOEqdTMRojWtCoS/vz9eeOEFHDlyBBs2bEBHRweefPJJTJ8+HV988QWam5v1lZPomVLFoKJOYjJXMN0sNowGqgkZjEENUvP5fKSlpSErKwsrVqxAVVUVVq9ejUmTJuG1115DS0uLrnMSPattaoeiW2Uy90DcLDbUHWW1ErofghAtDapAlJeX4/3338fEiROxYcMGPPzww9i9ezeysrJQUFCA5557Ttc5iZ6V1Yjh6mgFRztLtqPonL+nfc84RBGNQxCiDa2uYtq/fz++/fZbZGdnIzo6Gi+88ALuu+8+2Nj0TOwWGRmJ0NBQTJs2TS9hif70zsFkinrHIa4UNWJsvC/bcQgxGloViFWrViE9PR2vvvoqoqKi1O7j7u6OxYsX6yQcMZzyWuNeRe5O4sLcse9ECdsxCDEqWhWIY8eOwc7u9gvZW1tbY8mSJUMKRQyvrFaCRJEn2zH0JibUHR//9zJaJXI4m9CNgITok1ZjECkpKWhqurUft6WlBcOHD9dZKGJYim4lqhukJnkFUy9/T3s4O1jhKq0PQYjGtCoQDMOofV6hUEAgEOgkEDG8qoZ2KFUMArxMt0D0rg9B024QojmNuph2794NoOeX7Mcff+w3BbdSqcSZM2cQFBSkl4BE/8prxfB0sYGttZDtKHoVG+qGvcdpHIIQTWlUIP7+97/3ffzuu+/22yYUCuHv74/ly5frNhkxmDITWgPidmLDaByCEG1oVCByc3MBAJMnT8Z3330HV1dXvYYihlVWYzprQNyOn4c9XByscKWoEeMT/NiOQwjnaTUGcfjwYSoOJqi8VmIya0DcTt84BE27QYhG7ngGsXfvXkybNg2WlpbYu3fvbfe9//77dRaMGIasqxu1ze0mN0nfQGLC3LH3WBHbMQgxCncsEC+//DLGjBkDNzc3vPzyywPux+PxqEAYoco6KXjouQzUHMSFuePj7y6hRSKDi4M123EI4bQ7Foj8/Hy1HxPTUFYrho+7HSyF5nGZsq+7HVwde+ZlonEIQm7PoEuOEu4xlyuYevWtU033QxByR1oViBMnTuDcuXN9n3/77beYNWsWli9fDqlUqpNAjY2NWLZsGUaPHo2UlBTMmTOHFiXSo7JasdmMP/SigWpCNKNVgVi7dm3fWg8lJSV46623EBMTg6tXr2LNmjU6CfTmm2+ivr4e+/fvx5kzZzB16lQ888wzEIvFOjk+6a+8xvSWGb2T2DB3VNZL0SKWsR2FEE7TqkCUl5cjIiICQM/yo6NHj8abb76Jf/7znzh69KhOApWVlWH69OlwdXWFQCDAI488go6ODpSXl+vk+OQP7Z0KNLbJzOIeiJv1jENY0/oQhNyB1mMQPB4PAJCTk4OxY8cCALy8vNDa2qqTQAsWLMChQ4fQ0NAAhUKBbdu2ITg4uK8wEd0pr5XAQsCDr4d5XMHUq/d+iMvUzUTIbWk13bdIJML27dsxefJknD59Gq+++ioAoKamRmc30CUmJmL37t0YN24cBAIBnJ2d8dFHH8HSsv9KZ1lZWdi0aZNOXtNcldWK4e/pAAuB+V2rEBfuju9+vcF2DEI4Tau/DMuWLcP333+Pv/71r3jooYcQFhYGADhy5AhiY2OHHEalUuGJJ56At7c3srOzcfnyZbz11ltYsGABCgoK+u2bmZmJgoKCfg+inbJa8xt/6JUY4YmapnbUNLazHYUQztLqDCIlJQUnT55Ee3s7HB3/uPJl9uzZfcuODkVbWxsqKirw0UcfwcnJCQAwZcoUBAQE4MSJExCJREN+DfKH8loJ4sM92I7BCg8XGwR4OeB8QT3ucw9hOw4hnKR134JAIOhXHAAgMDAQHh5D/0Pj4uKC0NBQbNu2DVKpFCqVCr/++itu3LiB6OjoIR+f9Ndziat5nkEAQJLIExcK6tmOQQhnaXUGoVKpsGvXLpw8eRJNTU1QqVT9tm/dunXIgT7++GOsWbMGd999N+RyOfz8/PD6668jNTV1yMcmf2iVyNEm7TKLSfoGkiTyxHtbs6HoVkFoYX7jMITciVYFYvXq1di2bRtGjx4NPz+/viuadCk4OBgff/yxzo9L+iurFcPKUgBPF1u2o7AmOtQNSiWDa6VNiAszz642Qm5HqwKxb98+rFu3DtOnT9dXHmIgZbViBHo5gM/XfZE3FlZCAeLCPZCTV0cFghA1tDqv7u7uRlRUlL6yEAMqr5WY3RQb6oyM9saZ3NoB11snxJxpVSAeeOAB/PTTT/rKQgyorEaMIB/zHaDuNTLKCzWN7ais181cYoSYEq26mBwcHLBlyxZcuHABw4cPh1DYf5H7RYsW6TQc0Q+GYVBWK8Gj0+gMws3JBmH+TsjJq0WAFxVMQm6mVYHYvXs37OzskJ+ff8vaEDwejwqEkWho6USnvNusL3G92cgob5y+WouZaeFsRyGEU7QqEIcPH9ZXDmJAZbVi2NsI4epIK6oBwOg4X3z9cwGa2jrh5jT0Gz4JMRWDvvi7paWFBvaMVFmtBEE+jnq5TNkYBXk7wNfdHicv17AdhRBO0apAKJVKbNy4ESNGjMDYsWNRWVkJAFi3bh127Nihl4BE98x5DiZ1eDwexsX74sTlarajEMIpWhWIf/3rX9i9ezf+/ve/9xugjoqKwq5du3QejuhHeY0EwWZ8B7U6Y+N9kVfShGZaRIiQPloViF27duGNN97AQw89BD7/jy+NiIhAaWmprrMRPVAqVaiop3sg/izYxxG+7vY4drGK7SiEcIZWBaKmpgahoaG3PC8QCCCT0TsvY1DT1A5Ft4q6mP6Ex+MhLcUfR85VsB2FEM7QqkD4+fndcnkrAJw8eRLDhg3TWSiiP2W1Erg6WsPB1vLOO5uZtKQAFFW2oayG1j8nBNCyQGRkZOCdd97B8ePHAQClpaXYtm0b1q9fj8cee0wvAYluldeY9xTft+PpaovYUHc6iyDkd1rdBzFv3jy0trZiyZIlkMlkWLBgAaysrLBw4UL85S9/0VdGokO9l7gS9San+OM/P17D3HuGm+VSrITcTKsCAfQs9fmXv/wFjY2NYBgGYWFhsLU13ymjjU1ZrRgpwz3ZjsFZ4+L98K89V5GTV4vRsb5sxyGEVRoXiObmZqxbtw4///wzpNKeic0cHBwwdepULF26FK6urnoLSXSjS6FEdWM7AukKpgFZW1lgcnIAfjxZSgWCmD2NCkRnZycyMjLQ0tKCBx98EGFhYWAYBjdu3MC+fftw/vx5fP/997C2pqkbuKyqQQqVikEgTUp3W9NHByPz/SOoaWyHj7sd23EIYY1GBWLbtm2Qy+X44Ycf4OXl1W/bwoULMWfOHGzfvh1PPfWUTkJlZ2djw4YNuHbtGoRCIZKTk7F582adHNucldWI4e1mC2srrXsWzUqQjyOiQtyw73gxFjwUy3YcQlij0Sjc4cOHsXDhwluKAwB4eXlhwYIF+PXXX3USKCcnB4sXL8acOXNw6tQpHD9+HIsXL9bJsc1dGS0SpLGZaWH46UwZxO1dbEchhDUaFYji4mIkJycPuD0lJQVFRUU6CfT+++9j9uzZeOCBB2BtbQ1LS0vExcXp5NjmjuZg0lxKpBc8XWxx4GQJ21EIYY1GBUIqlcLZ2XnA7c7Ozn0D10PR0dGBS5cuAQBmzpyJ1NRUPPLIIzh16tSQj02AkmoxzcGkIT6fh1lpYdh7rBiyrm624xDCCo0KhFKphEAgGPggfD6USuWQw4jFYqhUKuzduxdvv/02jh8/jlmzZmHRokWoqOh/81JWVhZEIlG/BxmYpKMLja2dCPF1YjuK0ZiQ6A9LCz5+zaEb54h50mi0kmEY/O1vf7tlidFeCoVCJ2Hs7HquGJk1axaioqIAALNnz8aXX36JY8eOISMjo2/fzMxMZGZm9vt6KhIDK6lug6VQAF8Pe7ajGA2hBR8PTgzFrqOFmD4qCAK6cY6YGY0KxIwZM+64j7+//5DDODg4ICAg4JbnaWGboevpXnKAgE/fS21MTQ3Cjp+v4/ilakxMGvrPOCHGRKMC8e677+o7R5/HHnsMn332Ge69916EhYVh9+7dqKqqwoQJEwyWwRSVVLdR99Ig2FoL8eD4Yfj6UD7GxfvSWQQxK5y7IP6JJ55Ae3s75s+fj46ODoSHh+PTTz/VyRmKOSupEmPqqCC2YxilByeGYt+JEvySU4Fp9D0kZoRzBYLH42HJkiVYsmQJ21FMhqJbhfI6CUJ86QqmwbC1FuLhuyKw41A+0pL9YSkc+IINQkwJnS+bgcp6CbqVKrrEdQjuHRMM8Hh0XwQxK1QgzEBJtRg+bnawtVZ/FRq5M0uhAI9OFeHbX26gQ6abq/YI4ToqEGagpLoNIX509jBUd6UEwNHOEt8fLWQ7CiEGQQXCDNAVTLohEPDxZHoUdh0pRH1LB9txCNE7KhAmjmEYlFSLMYwKhE6MjPbG8BBXfLk/j+0ohOgdFQgT1yyWQdzehWC6gkkneDwenn4wFscvVeNaSTPbcQjRKyoQJq6kWgx7GyE8nG3YjmIygn0cMS01CFt+uAKVimE7DiF6QwXCxBVX9Yw/0HQluvXY9EhU1ktx9Hwl21EI0RsqECaOrmDSDyd7K8y5W4Qv9+dBJqfpwIlpogJh4oqr2hDiQwPU+pA+bhisLAX47xG67JWYJioQJkza0YXqxnaEBzqzHcUkCS34mH9/NL4/cgP1zXTZKzE9VCBM2I2KVthYCeDvScuM6svIaG/EhLpjyw9X2Y5CiM5RgTBhNypaEervTGtA6BGPx8PCGbHIyavD2Wt1bMchRKeoQJiw6+UtiAhwYTuGyfP1sMeMSaH4f7uuoEsx9KV3CeEKKhAm7EZFK40/GMjsuyLQrVJhF83TREwIFQgT1dTWiWaxjM4gDMTaygILHozBt79cRx0NWBMTQQXCRF0vb4WTvSU8XOgOakMZFeODmFB3/Gv3FbajEKITVCBM1I2KFoQHuNAd1AbUO2B9Lr8eOXm1bMchZMg4WyCee+45iEQinDlzhu0oRulGeSsiApzZjmF2fD3sMSstDJ98fxmddIc1MXKcLBC7d++GTCZjO4bRUqmYnjOIQBp/YMPsKRGwFAqw9QBNCU6MG+cKRG1tLTZs2IB//vOfbEcxWjVN7WiXdSOcziBYYSkU4G+PJOLAyVLkFjexHYeQQeNUgWAYBitXrsTixYvh6+vLdhyjdb28BZ6utnCyt2I7itmKDHZF+rgQZH17AXK6N4IYKU4ViO3bt4NhGDzyyCN33DcrKwsikajfg/S4UUHjD1wwb/pwKFUMth/MZzsKIYPCmQJRXl6OzZs34+2339Zo/8zMTBQUFPR7kB7Xy3uuYCLssraywAtzkrDntyKahoMYJc4UiLNnz6K1tRUzZ85EamoqUlNTAQDPPvssXn/9dZbTGY8uhRJFlW0QBVGB4ILoYW54bHokPth+DvUtdAMdMS4WbAfodc8992DMmDH9nps4cSLefvvtW54nA7tR0QoANEDNIbPSwpFX0ow1/zmLd58dB6EFZ96XEXJbnPlJtbGxgbe3d78HALi6usLJiRa80dS10maEBzjDUihgOwr5HZ/Pw4uPJqFZLMMX+3LZjkOIxjhTINQpKCjo62oimskraUJUiCvbMcifONpZYvlfR+Cn02X44VgR23EI0QinCwTRjkrF4FpJM6KGubEdhagREeiCV+Ym4/MfcnHkXAXbcQi5IyoQJqSiXgJppwLDg+kMgqtSY3zw/COJ+HDHBfx0uoztOITcFmcGqcnQ5RU3IdDbAQ62lmxHIbcxOSUAQgs+Pth+DopuJdLHDWM7EiFqUYEwIZcLGxEb6s52DKKB8Ql+EFrwsXrrWbRK5ciYGgk+LQ1LOIa6mEyESsXgSlEj4sKoQBiLUTE+eGvhaBw4UYr/+3c2OmQKtiMR0g8VCBNRXieBuL0LMXQGYVRiQ92x/sWJqGvuwMtZx1DdIGU7EiF9qECYiMuFDQjxcYKjHY0/GBsvV1usyRyPQC8HvLD+KF3hRDiDCoSJuHyjEbHUvWS0bKws8Mq8FDx5fww2fXsR678+TwsOEdZRgTABSqUKV2n8wejxeDzcMzoYH7wwEYWVrchcdwSXCxvYjkXMGBUIE3C9vBVyhRIxoXSDnCkI8nHE+hcmYnyCH/7x6Sl8/N9LNIBNWEEFwgScK6hDVIgbbK2FbEchOmIpFODx+6KwJnM8coubsHj1YRw9XwmGYdiORswIFQgTcD6/HsmRnmzHIHoQEeiCDS9OwoMTQvHxdxex/KPjKKpsZTsWMRNUIIxcm1SOwspWJEV6sR2F6InQgo+ZaWH4ZPkUeLnaYumG/2H91+fR0NLJdjRi4qhAGLkL1xvg4mCNIG8HtqMQPXN1tMbSjGSs+9sENLR0YtF7v2DrgTwanyB6Q1NtGLmc3FokR3qCx6NpGsxFeIAL3lk8Bjl5dfhiXy4OnSnDo1MjMW1UECwE9J6P6A79NBkxRbcKZ/PrMCrWh+0oxMB4PB5GRntj00tpeGxaJHYcKsCStUdw+moNDWQTnaEzCCN2pagRShWD+HAPtqMQlggEfNwzJgQTk/zx/ZFCrP3qHGJD3fDsrHh4utqyHY8YOTqDMGJnrtYgSeQJK1pe1OzZWgsx957h+PiVyWAAPLf2MPb8VgSlis4myOBxqkCsXbsW9913H5KSkjBu3DisXLkSLS0tbMfiJIZhkJ1bi9Rob7ajEA7xcrXFG0+PwnMPJ2Dnr9fx0sbfUFLdxnYsYqQ4VSAEAgHWrl2LM2fOYM+ePaitrcWKFSvYjsVJBWUtaJHIMZIKBPkTHo+HSUn++PiVuxDo5YClG/6Hb34pgFKpYjsaMTKcKhBLly5FVFQUhEIh3NzcMG/ePGRnZ7Mdi5N+u1iFRJEnrR5HBuRoZ4kXH03CiidGYt/xEiz/6DiqG2k6caI5ThWIPzt16hQiIyPZjsE5ShWDE5eqMD7Bj+0oxAiMjOq52snF0RrPv38UP54qpSudiEY4exXTgQMHsHPnTnz11Vdqt2dlZWHTpk0GTsUNecVNkHQoMCqGupeIZpzsrbDi8RE4fLYCn+66guzcWmTOToCrozXb0QiH8RgOvpXYv38/3njjDWRlZWHUqFEaf51IJEJBQYEek3FD1rcXIenowsonRrIdhRih+uYObNhxAaU1Yjz3cDzGxvmyHYmw6HZ/NznXxbRz5068+eab+OSTT7QqDuZCJu/GsYtVmDIikO0oxEh5utri7UVj8PBd4Vj31Tms//o82jtpug5yK04ViK1bt2LdunX47LPPkJyczHYcTjp5pQZWlgKavZUMCZ/Pw4xJYVj/4kSUVLch8/0juFLYyHYswjGc6mISiUSwsLCApWX/K3P2798PX987nwabQxfTyo9PIDzAGU/eH812FGIiFN1KbDuYj13/K8ID44dh3j3DYUk3X5qN2/3d5NQgtan/cR+q6gYprhY3YvGsOLajEBMitBDgifRojIjyxgdfn8eFgnr8bU4iwgNc2I5GWMapLiZye/tOlCA21B0BXjS1N9G96GFuyFo2CZHBrnhp4zF89sNVyOTdbMciLKICYSQ6ZAr8kl2O9HHD2I5CTJittRBLHk7A24vGIDu3FkvWHcHF6/VsxyIsoQJhJA6frYCDrZCm1iAGERvqjo0vpWFCoh/e+NdprP/6PFokMrZjEQOjAmEEupUq7DpaiPvHh0LAp4WBiGFYCQX4671R+OCFiahukGLxe79i77FimtPJjFCBMAJHz1VC1qXE9FFBbEchZmiYnxNWLxmPpx+MxTe/FOCF9f9DbnET27GIAVCB4DilisF3h6/jwQmhsLbi1EVnxIzw+TxMGRmIT5ZPQcwwN6zcfALvfZmDynoJ29GIHlGB4LjDOeUQt3fhvrEhbEchBPY2QiycGYeNSyehW6nCc2uPYNPOi6hpbGc7GtEDekvKYTJ5N746eA1z7hbBzkbIdhxC+gT5OOK1p1JxraQZXx28hoXv/YLkSC+kjwtBQoQnjZWZCCoQHLbraCGshBa4ZwydPRBuGh7iincWj0VJdRv2nyjB//07B9aWAqQM98KIKC/Eh3vQmiVGjAoER1U1SLHz8A28Mi8FQgvqCSTcFuLrhCUPJ+Cp+6NxoaAB2Xm1+OT7y2iTdiHQ2wHRIW6IHtbzcHe2YTsu0RAVCA5SqRhs2nkRI6O8MSrGh+04hGjM1lqIsfG+GBvvC5WKQUWdBLklTcgtbsIX+3LR1CaDp6stkkSemJDgh6hhbtQdxWFUIDhoz29FKK0W46NXJrMdhZBB4/N5CPJxRJCPI+4dEwKGYVDX3IHc4iacya3F6/86BXsbISYlB+DeMcHwdrNjOzL5EyoQHJNf2oytB/Kw4vGRtNoXMSk8Hg/ebnbwdrPDXSMC0SFT4PTVWvx0uhS7/1eIEcO9cf/4EMSHe4DHo7MKLqACwSF1zR34v39nI33cMJpSg5g8W2shJqcEYHJKAIoqW7H/RAne+uwM/D3t8dDEUIxP8KfxN5Zxaj2IoTLm9SBaJXIs/+g4ArzssfzxkdQvS8xSi0SGAydKceBkCSwEfKSPC8HdI4Pg7GDFdjSTdbu/m1QgOKC+pQP/+PQkXB1t8PqCUbCixVqImZMrlDhytgI/HCtCdUM7UoZ74a4RgUiK9KTfDx0zmgWDzNGVwkas/eoswgNc8MpfU+iHnxD0TBQ4fXQwpo0KQkF5C37NqcCHO86jq1uF6BA3JER4IDzQGQFeDnC2t6IxCz2hMwiWdMgU2P5TAfYdL8ZfJofj0akiCATU30rIQBTdKhSUNePC9QZcut6AkhoxuhRKONgK4e5sAyc7KzjaWfY97G0tYW8rhL2NEPY2N31sK4TQgt6I9TKqLiaVSoUNGzbgu+++Q2dnJ5KSkvDWW2/Bz8/vjl9rDAWiRSLDodNl+OFYMZwdrLBoZhxiQ93ZjkWI0VGpGDS0dqKiToKmNhnE7XKI27vQJu35V9qpgLRDgfZOBSQdXVCq/vhTZykUwMFWCCc7KzjZW8LZwQpO9lZwtrfq+9jFwQruzjZwtLM06TMUo+pi2rJlC/bt24evvvoKXl5eeO+997Bo0SLs2bMHfL7xvcOWdipQXivG9fIWnM+vx6XCRvh52OPJ9GhMSvaHBZ01EDIofD4PXq628HK1veO+DMNA1qWEtEMBaWcXpB09RaPt94LSJpGjsbUThZWtaJPK0SrpgqSjCwBgIeDD3dkabk42cHey+ePjvn9t4GRvZZIXlnCuQOzYsQNPP/00hg3rWVrz5ZdfxpgxY3Du3DmMGDFCL68p6+qGpF0BhmGgYhioVDf/2/PDpVQxPdtVDFQqQKFUQiZXolPeDVlXNzrlyt+P04UWiRzNYhnqmtrR2CaDhYCPYF9HJIR7YN69wxHm72zS70gI4RoejwcbKwvYWFnAw0WzqT4U3So0i2VobO1EU1snGltlaGrrRE1TO64WNaGxrRMtYhlUDCDg8+DqZA13Jxs42FpCKOTD0oIPoYWg519h7798CAV8CAR8WAj4sBDwYPH75z3P8/qev/U5/u/78sAD7/d29Tyc7K308maTUwVCIpGgqqoKMTExfc85OjoiKCgI165d01uBePvzM7h0o1Gjffm8nncuQgsBbKwEsLa0gPXvP3jWlgLY2Qjh5mSNMH9neLjYINjHET7udnSmQIiREVrw73iGolSq0CKRo7GtE02tMjS0dkLa2QWFQoWubiUU3Sp0yLvRJZVD0a2CXKGEUsmgW6m66cFAedPH3UpVz+cqBt3dqn5dYwOZlRaGJ9Kjddl8ABwrEFKpFEBPUbiZg4ND37ZeWVlZ2LRp0y3HEIlE+gtICCEc9O4+4N1luj8upwqEvb09gJ4ziZtJJJK+bb0yMzORmZmp8bGNYQBbV6itponaapq43FZO9Xs4ODjAz88PV69e7XtOIpGgvLwcw4cPZzEZIYSYH04VCACYM2cOPvvsM5SUlKCjowNr165FcHAwkpOT2Y5GCCFmhVNdTADw9NNPQyKRICMjA52dnUhOTsbmzZuN8hJXQggxZpwrEHw+H8uWLcOyZbodcVmyZIlOj8dl1FbTRG01TVxuK+fupCaEEMIN1G9DCCFELSoQhBBC1DKZAvHvf/8bkyZNQnx8PObMmYP8/Pzb7l9RUYH58+cjMTERY8aMwfr163Fzb1tWVhaGDx+OxMTEvsfSpUv13YxbqFQqfPDBBxgzZgwSExMxf/58VFVVDbh/Xl4e5syZg/j4eEyaNAlbt27tt10mk+Ef//gHRo4ciaSkJLzwwgtobW3Vcys0o+u2Ll++HNHR0f3+D9euXavvZmhEm7bKZDI8//zzmDp1KiIjI5GVlTWk4xmartvKld9NdbRp68WLF/HMM89gzJgxSEpKwowZM3Do0KFBH08vGBOwb98+ZsSIEcyFCxcYmUzGZGVlMWPHjmUkEona/bu7u5l7772Xee211xipVMoUFRUxaWlpzJYtW/r22bhxIzN37lxDNWFAn376KZOWlsYUFRUxUqmUee2115j09HRGqVTesq9EImFGjx7NZGVlMTKZjLlw4QIzYsQI5scff+zbZ9WqVcyMGTOY2tpaprW1lVmwYAHzzDPPGLJJA9J1W1999VXm1VdfNWQTNKZNW2UyGfPFF18wp06dYh5++GFm48aNQzqeoem6rVz53VRHm7YePXqU2bVrF9PU1MQolUrm4MGDTExMDHPp0qVBHU8fTKJAzJ07l1mzZk3f50qlkhk7diyza9cutfufPn2aiY6OZtra2vqe27ZtGzN58uS+z7nyQ5iWlsZs27at7/O2tjYmOjqayc7OvmXf//73v8zYsWP7/fCsWbOGmTdvHsMwDNPZ2cnExsYyR48e7dteWFjIREREMFVVVXpshWZ02VaG4XaB0KatN5s7d67aP5qDPZ4h6LqtXPndVGeo/w8zZsxgPv/8c50db6hMoospPz+/3wR/fD4fUVFRuHbt2oD7BwUF9ZvzKSYmBpWVlf3mfLp69SpGjRqFtLQ0LFu2DBUVFfprhBp3mrzwz/Lz8xEVFdXvnpGYmJi+7rbS0lLI5XLExsb2bQ8NDYWNjc2A3ytD0XVbe/3yyy9ITU3FlClT8I9//APNzc36a4SGtG2roY+nS/rKxvbvpjpDbWtdXR2Ki4sRGRmpk+PpAqcLxPLlyyESiQZ8PP/88wB6JvnTZIK/XlKpFA4ODv2e6/363q+ZNm0a9u3bh1OnTmHHjh0QCAR48skn0d7erutmDkibyQt791fXrt59e//98z63+14Ziq7bCgBz587Fjz/+iNOnT+Pzzz9HVVUVFi9e3G+siQ3attXQx9MlfWTjwu+mOkNpa3t7OzIzM5GWlobRo0cP+Xi6wrkb5W62atUqvPLKKwNut7S0BNAzyZ+6Cf7c3dWv1GZvb3/LN1gsFvdtA4CIiIi+bV5eXnjnnXeQkpKCCxcuYNy4cdo3ZhC0mbywd/+mpqZ+z4nF4r59bz6eq6vrHY9nSLpuK4B+77wCAwPxzjvvYOLEiSgtLUVISIgu42tF27Ya+ni6pI9sXPjdVGewbZVIJHjmmWfg4eGB1atXD/l4usTpMwg7Ozu4uroO+Oj9JkVGRvab4E+lUiEvL2/ACf4iIyNRVlbW7xufm5sLf3//Ab/xPB4PPB7PoO8+tZ28MDIyEnl5eVCpVH3P5ebm9p2yBgcHw8rKqt/xioqK0NnZ2bcPW3TdVnV6F2li+wxC15NScnmSS0NkY+N3U53BtLWlpQWPP/44fHx88OGHH/a96R3s8XSN0wVCU3PmzMHOnTtx+fJldHV1YfPmzQCAKVOmqN0/JSUFgYGBWLt2LTo6OlBSUoItW7bg0Ucf7dvnwIEDff3VTU1NWLVqFVxdXZGYmKj/Bt1Em8kLp06dCqVSic2bN6OrqwuXL1/Gzp07+9plbW2Nhx56CBs3bkR9fT3a2tqwdu1aTJw4UaM1v/VNl22Vy+U4ePBg35uAqqoqrFq1CtHR0QgODjZks9TSdlLKrq4uyOVyqFQqdHd3Qy6Xo6ura9DHMyRdt5Urv5vqaNPWhoYGzJs3DyKRCOvWrYOFxa0dOqz/vxpkKNwAvvjiC2bChAlMbGws88gjjzDXrl3r21ZVVcUkJCQwOTk5fc+Vl5czTz31FBMfH8+MGjWK+eCDDxiVStW3feHChUxqaioTFxfHjBs3jnnxxReZ0tJSg7aJYXquyFq3bh0zatQoJj4+nnnqqaeYiooKhmEYJicnh0lISOh3BVJubi4ze/ZsJjY2lpkwYQLz5Zdf9jteZ2cn89prrzEpKSlMYmIi8/zzzzMtLS2GbNKAdNnWjo4O5tFHH2VGjBjBxMfHM5MmTWJWrVrF1NfXG7xd6mjb1rS0NCYiIqLf4+YreW53PLbpuq1c+d1UR5u2ZmVlMREREUx8fDyTkJDQ91i1apVGxzMEmouJEEKIWibRxUQIIUT3qEAQQghRiwoEIYQQtahAEEIIUYsKBCGEELWoQBBCCFGLCgQhhBC1qEAQQghRiwoEIYQQtf4/G7w4EehkZMMAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "needs_background": "light"
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -10186,16 +10214,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 305,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.041109396421711186"
+       "0.041109421009255215"
       ]
      },
-     "execution_count": 305,
+     "execution_count": 62,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10213,29 +10241,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 300,
+   "execution_count": 63,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/qq06/anaconda3/envs/openproblem/lib/python3.8/site-packages/scipy/stats/stats.py:3845: PearsonRConstantInputWarning: An input array is constant; the correlation coefficent is not defined.\n",
-      "  warnings.warn(PearsonRConstantInputWarning())\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from scipy.stats import pearsonr\n",
-    "cors = []\n",
-    "for i in range(adata.layers['X_knn'].shape[1]):\n",
-    "    cors.append(pearsonr(adata.layers['X_knn'].toarray()[:, i],\n",
-    "                         adata.layers['gene_score_knn'].toarray()[:, i]))"
+    "cors = Parallel(n_jobs=-1)(\n",
+    "    delayed(pearsonr)(\n",
+    "        adata.layers['X_knn'].toarray()[:, i],\n",
+    "        adata.layers['gene_score_knn'].toarray()[:, i],\n",
+    "    )\n",
+    "    for i in range(adata.layers['X_knn'].shape[1])\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 301,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [
     {
@@ -10244,20 +10265,18 @@
        "<AxesSubplot:ylabel='Density'>"
       ]
      },
-     "execution_count": 301,
+     "execution_count": 64,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAD4CAYAAADhNOGaAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAAqmUlEQVR4nO3dd3Sc9Z3v8fd31Jslq1pWsST33mTLxqE7wQECBNilBBJCWJYkm757LzfJ5rDJ7t1kzyZ7yWZDICQBQighlJiapZrqImzLRZbcJFvdKpY0Vpfme/+YsdcY2ZJsjZ4p39c5czwzz6PR5zkjz3ee3+/3/H6iqhhjjAlfLqcDGGOMcZYVAmOMCXNWCIwxJsxZITDGmDBnhcAYY8JcpNMBxio9PV0LCgqcjmGMMUHlww8/bFHVjOG2+a0QiEge8AiQBSjwgKree8o+FwF/Bqp8Tz2jqj880+sWFBRQWlo67nmNMSaUicih023z5xnBIPAdVd0qIknAhyLyqqqWn7LfO6p6pR9zGGOMOQO/9RGoaoOqbvXddwN7gBx//T5jjDFnZ0I6i0WkAFgKbBpm82oRKRORl0Vk/ml+/k4RKRWR0ubmZn9GNcaYsOP3QiAiicDTwDdVtfOUzVuBaaq6GPhP4LnhXkNVH1DVYlUtzsgYtq/DGGPMWfJrIRCRKLxF4A+q+syp21W1U1WP+e6/BESJSLo/MxljjPkovxUCERHgN8AeVf3ZafaZ4tsPEVnpy9Pqr0zGGGM+zp+jhtYAtwI7RWS777nvAvkAqvor4HrgyyIyCPQAN6pNh2qMMRPKb4VAVd8FZIR9fgH8wl8ZTHga8igeVSJdgu+E0xhzBkF3ZbExp1Pd0sV9bx3gxZ0NHOsbJCU+is+V5HPHJ4qYnBDtdDxjApYVAhMSnttWx/ee3YkCly/MZlpqPLvqO/jlWwd4vqyBh29fSWF6gtMxjQlIVghM0HuqtIZ/+NMOVhamcu+NS8hOjjuxbevho9zxcCnX3fc+z31lDflp8Q4mNSYw2eyjJqi9VXmEu5/ZySdmpPPol0o+UgQAluVP5qm7VjM45OGuRz+kd2DIoaTGBC4rBCZo7azt4Ct/2MrsrCTuu2UZ0ZHD/zlPz0jk/924hPKGTv75xVOnujLGWCEwQelwazdffGgzk+OjeeiLK0iKjTrj/pfMyeL2NYX8YdNhth4+OkEpjQkOVghM0Gnr6ucLv9vMoEd5+PaVZE6KHdXPfftTs8hMiuH7z+5icMjj55TGBA8rBCao9PQPcftDW6hv7+HBzxczIzNx1D+bGBPJP145j/KGTp7dVufHlMYEFxs1ZMZV78AQVS1dHHH34e4dQBWSYiOZkhzL9IxEoiLO/rvH4JCHrz2+jbLadu773HKKC1LH/BpXLMzm/pyD3Pv6Pq5eknPafgVjwokVAnPWPB6lssnN+wda2XSwlcomN4fbujndJCHRES6WTUth7dwsrlmaQ3pizKh/18CQh68/vo3X9jTxo6vns27BlLPKLCJ851OzuO13W3iytIZbV007q9cxJpRIsE3tU1xcrLZUpbP2H3Hz6MbDvLCjnpZj/QBMS4tnwdRkZmQmMjMrkezkWJJioxCgs3eQ2qPd7Kzt4N39LVQ0uomKEC6bP4WbVuazuigNl+v0U0G0dfXzzSe38/beZr5/xVzuOL/onPKrKtf/6gMaO3p56x8uOqezFGOChYh8qKrFw22zMwIzakfcvfzfF/fw57J6olwu1s7L5JI5WayenkZOStwZf3b5tMlcvcS7QN2+JjePb67h6a21vLCjgbzUOP5qeR7XL89l6kmvMzDk4bltdfz0v/fS1tXPj69dyI0r88/5OESEr1w0nS89XMqLOxq4ZqktnGfCm50RmFF5q/II3/ljGcf6BvnimkLuvKCI1HOcv6d3YIhXdjXyx9Ia3j/gnX08PzWevNQ4BoaU8vpOjvUNMn/qJH5y3SIW5CSPx6EA3matdfe+jUuEl79xvk1OZ0KenRGYc7K+rJ5vPbmdmZmJPHHnKmZmJY3L68ZGRXDN0hyuWZrD4dZuXt7VwLbD7TQf6wPgs0tzuGROJhfNzhj3D2qXS7jzgun8/VNlvLOvhQtm2cp3JnxZITBn9Fp5E998YhvFBan89rYVJMb4508mPy2ev71wul9e+3Q+szibf31pD7/feMgKgQlr1ktmTqu6pYtv/XE786cm89AX/VcEnBITGcGNK/N4fU8Tde09TscxxjFWCMywBoc8/N3jW3GJ8MvPLSM+OrSKwHE3l3iHj/5h4yGHkxjjHCsEZlh/2HSYXXWd/MtnF5CXGrpTN+ekxHHp3Cye3FJD36DNTGrCkxUC8zHN7j7+/b8rOX9mOlcszHY6jt99fvU0Wrv6eXlno9NRjHGEFQLzMb98az/d/UPcc9X8sBhWuWZ6OkXpCTzyQbXTUYxxhBUC8xEtx/p4fPNhPrs0h+kZo5/QLZi5XMItq6ax9XA7u+o6nI5jzISzQmA+4jfvVtE36OHLF03sUE6nXbc8l9goF49vPux0FGMmnBUCc0J3/yCPfnCIyxdmh83ZwHHJcVFcsXAqf95eT1ffoNNxjJlQVgjMCS+UNeDuG+S28wqcjuKIm0vyONY3yAs76p2OYsyEskJgTnhs82FmZCZSPG2y01EcsSx/MrOyEnlsc43TUYyZUFYIDAB7GjrZXtPOTSvzw2Kk0HBEhBtX5FNW0055fafTcYyZMFYIDABPf1hLVIRwbZhPyXztMu+qZU9ssU5jEz6sEBg8HuWlnQ1cMDODyec4tXSwS4mP5oqF2Ty7tY6efrvS2IQHKwSGbTXt1Hf0cuXi0L+KeDRuWpmP2zqNTRixQmB4YUc90ZEu1s7NcjpKQFhRMJnpGQl2TYEJG1YIwpzHo7y8s5GLZmWQFBvldJyAICLctDKfrYfbqWi0TmMT+qwQhLnd9Z00dvZy2fwpTkcJKNcuyyU6wsUTNpTUhAErBGHuzcojiMCFs22FrpOlJkSzbsEUntlaa53GJuRZIQhzb1QcYVFuCumJMU5HCTg3rcyns3eQl3Y2OB3FGL/yWyEQkTwReVNEykVkt4h8Y5h9RER+LiL7RWSHiCzzVx7zca3H+iirbeeS2ZlORwlIq4pSKUy3TmMT+vx5RjAIfEdV5wGrgK+KyLxT9vk0MNN3uxO4z495zCneqmxGFS6ZY4VgON5O4zxKDx1lX5Pb6TjG+I3fCoGqNqjqVt99N7AHOPWy1auBR9RrI5AiIjaYfYK8u7+FtIRo5k+d5HSUgHXdslyiIoTHrdPYhLAJ6SMQkQJgKbDplE05wMn/w2r5eLFARO4UkVIRKW1ubvZbznCiqry3v4XV09NwucJzbqHRSEuM4VPzp/D01lp6B6zT2IQmvxcCEUkEnga+qapnNShbVR9Q1WJVLc7IsNEt4+FAcxdH3H2smZHudJSAd/PKfDp6Bnhll61pbEKTXwuBiEThLQJ/UNVnhtmlDsg76XGu7znjZx8caAHgvOlpDicJfKuL0piWFs9jm6zT2IQmf44aEuA3wB5V/dlpdlsPfN43emgV0KGqNlZvArx/oJWclDjyU+OdjhLwXC7v9NSbq9uobLROYxN6/HlGsAa4FbhERLb7bpeLyF0icpdvn5eAg8B+4NfAV/yYx/h4PMoHB1tZPT0tbNceGKsbVuQRHeni9xurnY5izLiL9NcLq+q7wBk/ZVRVga/6K4MZ3r4jx2jvHmBVkTULjVZqQjRXLvJOT/2/182xeZlMSLEri8NQ6aE2wDvLphm9L6wuoKt/iGe2WjeWCS1WCMJQafVR0hNjrH9gjBbnpbA4N5lHPqjGezJrTGiwQhCGSg+1UTxtsvUPnIVbVxdwoLmL9w+0Oh3FmHFjhSDMNHX2UtPWQ7E1C52VKxdlMzk+ikc+qHY6ijHjxgpBmCmtPgpAcUGqw0mCU2xUBDesyOfV8ibq2nucjmPMuLBCEGY+PHSU2CiXzS90Dj5Xko8Cj2065HQUY8aFFYIws6O2nQVTk4mKsLf+bOWlxnPpnEye2FxD36DNP2SCn30ahJHBIQ+76ztZmJvsdJSgd+vqAlq7+nl5p80/ZIKfFYIwcqC5i56BIRZZIThn589IpzA9wTqNTUiwQhBGdtS2A7AwJ8XRHKHA5RJuWTWNrYfb2VXX4XQcY86JFYIwsqO2g8SYSIrSE5yOEhKuX55LXFSEnRWYoGeFIIzsqOtgQc4kW4hmnCTHRXHN0qn8eXs97d39Tscx5qxZIQgT/YMe9jR0sig3xekoIeXWVQX0DXp4qrTW6SjGnDUrBGFib5Ob/kEPC3Oso3g8zZs6iRUFk3l00yE8Hpt/yAQnKwRhYkett0NzsZ0RjLtbVxdwqLWbDftsPW0TnKwQhImdde0kx0WRlxrndJSQs27+FNITY/jDRlvK0gQnKwRhYkdtB4tyk23GUT+IjnRx3bIc3qo8QsuxPqfjGDNmVgjCQO/AEJWNbusf8KO/Ks5l0KM8t80WrTHBxwpBGKhodDPoURsx5EczMpNYkpfCU6W1tmiNCTpWCMLA8SuKbWoJ/7p+eS6VTW5213c6HcWYMbFCEAZ21naQlhBNdnKs01FC2hULs4l0CevL6p2OYsyYWCEIAxWNbuZmT7KOYj+bnBDNhbMyeL6s3q4pMEHFCkGIG/Ioe5vczJ6S5HSUsHDVkqk0dPRSeuio01GMGTUrBCHuUGsXfYMeKwQTZO3cLGKjXKwvs9FDJnhYIQhxlY1uAOZYIZgQCTGRXDInk7/sbrLmIRM0rBCEuIpGNyIwM9MKwUS5bP4Umt19bKux5iETHKwQhLjKRjcFaQnERUc4HSVsXDInk+gIF6/ssmUsTXCwQhDi9ja5mZ1lZwMTKSk2ijUz0nhld6NdXGaCghWCENY7MER1a5d1FDvgsvlTqGnrYU+D2+koxozICkEI29d0DI9aR7ETLpmbCcAbFU0OJzFmZFYIQlhFo3eqAzsjmHiZSbEsyk3mjYojTkcxZkRWCEJYZaOb2CgX09JssXonXDw7k2017bR12XrGJrBZIQhhlU1uZmYmEWGL1TvikjmZqMKGvXZWYAKbFYIQVtFoU0s4aWFOMumJMbxRYUtYmsDmt0IgIr8VkSMisus02y8SkQ4R2e67/cBfWcJRW1c/ze4+GzrqIJdLOH9mOu/vb7GrjE1A8+cZwUPAuhH2eUdVl/huP/RjlrBjHcWBYc2MdFq7+qlssmGkJnD5rRCo6ttAm79e35yZzTEUGNbMSAPgvf0tDicx5vSc7iNYLSJlIvKyiMw/3U4icqeIlIpIaXOztbeORmWjm8nxUWQkxTgdJaxlJ8dRlJFghcAENCcLwVZgmqouBv4TeO50O6rqA6parKrFGRkZE5UvqB3vKLbFaJy3Zno6m6ra6B/0OB3FmGE5VghUtVNVj/nuvwREiUi6U3lCice3GM2cKZOcjmLwNg919w9R5ls72phAM6pCICLPiMgVIjJuhUNEpojv66qIrPRlaR2v1w9ntUd76O4fso7iALG6KB0R6ycwgWu0H+y/BG4G9onIj0Vk9kg/ICKPAx8As0WkVkS+JCJ3ichdvl2uB3aJSBnwc+BGtakax4WNGAosyfFRLMxJtkJgAlbkaHZS1deA10QkGbjJd78G+DXwqKoODPMzN43wmr8AfjH2yGYkx0cMzbJrCALGmhnp/Prtg3T1DZIQM6r/dsZMmFE39YhIGnAbcAewDbgXWAa86pdk5qxVNLnJS40j0T5wAsaa6ekMepTNVTai2gSe0fYRPAu8A8QDn1HVq1T1SVX9GpDoz4Bm7PY2upmdZR3FgaS4YDLRkS5rHjIBabRfGX/tG9lzgojEqGqfqhb7IZc5S32DQxxs6eKy+VOcjmJOEhsVQfG0ybx/wMZDmMAz2qahfx7muQ/GM4gZHweOdDHkUesoDkAlhWnsaeyko/tjXWrGOOqMhcA3xHM5ECciS0Vkme92Ed5mIhNgKpu8I4ZsaonAU1KUiipsqbZ+AhNYRmoaugxvB3Eu8LOTnncD3/VTJnMOKhrdREUIBem2GE2gWZKXQnSki01Vraydl+V0HGNOOGMhUNWHgYdF5DpVfXqCMplzUNnoZnpGIlERTk8jZU4VGxXBkrwUNtnIIRNgzlgIROQWVX0UKBCRb5+6XVV/NsyPGQdVNropKUx1OoY5jVWFqfzizf24ewdIio1yOo4xwMidxcfbFxKBpGFuJoB0dA/Q0NHLbJtjKGCVFKXhUSitPup0FGNOGKlp6H7fv/80MXHMuTi++Il1FAeuZfmTiYoQNla1cvGcTKfjGAOM/oKyfxORSSISJSKvi0iziNzi73BmbCptjqGAFxcdwaLcFDYdtH4CEzhG26P4KVXtBK4EqoEZwD/4K5Q5OxWNbpJiI8lOjnU6ijmDksJUdtZ10NU36HQUY4DRF4LjTUhXAE+paoef8phzUNnoZo4tRhPwSorSGPIoHx6yfgITGEZbCF4QkQpgOfC6iGQAvf6LZcZKValscluzUBBYPm0yES5hU5VNN2ECw6gKgareDZwHFPumnO4CrvZnMDM29R29uHsHbcRQEEiMiWRBTrL1E5iAMZZ5iufgvZ7g5J95ZJzzmLN0vKPYRgwFh1WFqfz2vSp6+oeIi45wOo4Jc6MdNfR74N+BTwArfDebdTSAVNhiNEGlpCiVgSFl22HrJzDOG+0ZQTEwz5aSDFx7G91MTY4lOc6uVg0GxQWpuAQ2VrVx3ox0p+OYMDfazuJdgE1wH8AqGq2jOJhMio1i3tRJbDpoHcbGeaM9I0gHykVkM9B3/ElVvcovqcyYDAx5ONB8jAtnZzgdxYxBSWEav994iN6BIWKjrJ/AOGe0heAef4Yw56aqpYuBIbWO4iBTUpjKb96toqymnZKiNKfjmDA22uGjG/BeURzlu78F2OrHXGYMjncU2zrFwWVlYSoi2LTUxnGjHTX0N8CfgPt9T+UAz/kpkxmjysZOIlzC9ExbjCaYpMRHMzsryS4sM44bbWfxV4E1QCeAqu4DbOrEAFHZ6KYoPYGYSGtnDjaritL48NBR+gc9TkcxYWy0haBPVfuPP/BdVGZDSQOEjRgKXiWFqfQOeNhZ1+50FBPGRlsINojId/EuYv9J4Cngef/FMqN1rG+Q2qM91lEcpFb6VpPbaNNNGAeNthDcDTQDO4G/BV4Cvu+vUGb0Ko93FNscQ0EpLTGGmZmJ1mFsHDWq4aOq6hGR54DnVLXZv5HMWBwvBHZGELxKilJ5dmsdg0MeIiNG+93MmPFzxr868bpHRFqASqDStzrZDyYmnhlJZWMnCdER5KTEOR3FnKWSwjS6+ofYVd/pdBQTpkb6+vEtvKOFVqhqqqqmAiXAGhH5lt/TmRFVNLqZNSUJl8sWowlWJUXefgKbbsI4ZaRCcCtwk6pWHX9CVQ8CtwCf92cwMzJVpaLRzRzrHwhqmUmxFKUnWD+BccxIhSBKVVtOfdLXT2DTXDqsvqOXjp4B5k+1QhDsSopS2VLVxpDHRmWbiTdSIeg/y21mApT72pTnWSEIeiWFabj7BtnTYP0EZuKNVAgWi0jnMDc3sPBMPygivxWRIyKy6zTbRUR+LiL7RWSHiCw724MIV+X1nYjYiKFQcLyfYKP1ExgHnLEQqGqEqk4a5pakqiM1DT0ErDvD9k8DM323O4H7xhLcQHlDB4XpCcRHj2XFUROIspPjyE+Nt34C4wi/DVpW1beBM/1VXw08ol4bgRQRyfZXnlBU3tDJvGxrFgoVJYWpbKluw2P9BGaCOXn1Sg5Qc9LjWt9zHyMid4pIqYiUNjfb9WwAHT0D1LT1WP9ACCkpSqO9e4DKJrfTUUyYCYrLGFX1AVUtVtXijAxbhQugwtepaGcEoaOk0K4nMM5wshDUAXknPc71PWdGobzBRgyFmrzUeHJS4qyfwEw4JwvBeuDzvtFDq4AOVW1wME9QKa/vJD0xhsykWKejmHFUUpjKpirrJzATy2+FQEQeBz4AZotIrYh8SUTuEpG7fLu8BBwE9gO/Br7iryyhqLyh084GQtAFszJo6+pnR12H01FMGPHbuENVvWmE7Yp35TMzRv2DHvY1HeP8mdZfEmounJWBS+CNiiMsyUtxOo4JE0HRWWw+6kDzMfqHPHZGEIImJ0SzNH8yb1Q0OR3FhBErBEHoxNQSNmIoJF0yJ5NddZ0c6ex1OooJE1YIglB5QyexUS4K0xOcjmL84JI5mQC8WXnE4SQmXFghCELl9Z3MmTKJCFuDICTNmZJEdnIsb1RYITATwwpBkPF4lF31HdY/EMJEhIvnZPLOvhb6BoecjmPCgBWCIFPV2oW7d9BGlIS4S+dk0t0/xGa7uMxMACsEQaasph3ACkGIO296OjGRLmseMhPCCkGQKatpJyE6gukZiU5HMX4UFx3B6ulpvFFxBO8lN8b4jxWCILO9toOFucnWURwGPjkvi0Ot3expsNlIjX9ZIQgifYND7KnvZLE1C4WFTy/IJsIlPL+j3ukoJsRZIQgiexrc9A95WGqFICykJkTziRnpPF9Wb81Dxq+sEASR4x3FdkYQPj6zeCq1R3vY5nvvjfEHKwRBpKymncykGKZMsqmnw8Wn5mcRHeli/XZrHjL+Y4UgiGyvbWdxXgoi1lEcLibFRnHx7Axe3NnAkK1RYPzECkGQ6OgZ4GBzl10/EIY+s3gqze4+W8LS+I0VgiCxs9a7UMni3BRng5gJd+mcLOKjI2z0kPEbKwRBoqy2HYCFucnOBjETLi46gk/Oy+KlnY0295DxCysEQWLb4XamZySQHBfldBTjgGuW5tDRM8Cr5bZgjRl/VgiCgKqyvabdmoXC2AUzM8hJiePxzYedjmJCkBWCIFDd2k3LsT6KC1KdjmIcEuESbliRx3v7W6lu6XI6jgkxVgiCwPHRIiVFVgjC2V8X5+ESeGJLjdNRTIixQhAENle1kZ4YTZEtTRnWpiTHcsmcLP70YQ39gx6n45gQYoUgCGyqamNlYapdSGa4uSSPlmP9vL7HOo3N+LFCEOBqj3ZT195DSWGa01FMALhwVibZybE8Zp3GZhxZIQhwmw56lypcWWj9A+Z/Oo3f2ddincZm3FghCHCbq9pIjotidlaS01FMgLh5ZT5REcJD71c7HcWECCsEAW5TVSsrClJx2YpkxidzUiyfWTSVp0pr6OwdcDqOCQFWCAJYU2cv1a3dlFizkDnFF9cU0tU/xB9tKKkZB1YIAtjmKm//gF0/YE61MDeZlQWp/O69agaHbCipOTdWCALYpqpWEqIjmJc9yekoJgDd/olC6tp7eM2GkppzZIUggG2uamN5QSqREfY2mY/75Lws8lLj+O271U5HMUHOPmEC1JHOXvY2HWOVNQuZ04hwCbedV8jm6ja225rG5hxYIQhQb+9rAeDCWRkOJzGB7IYVeUyKjeRXbx1wOooJYlYIAtSGvc1kJMVY/4A5o8SYSL5wXgF/KW9k/5FjTscxQcqvhUBE1olIpYjsF5G7h9l+m4g0i8h23+0Of+YJFkMe5Z19zZw/M93mFzIjuu28AmIiXdy/wc4KzNnxWyEQkQjgv4BPA/OAm0Rk3jC7PqmqS3y3B/2VJ5jsqG2nvXvAmoXMqKQlxnDjinye3VZHfXuP03FMEPLnGcFKYL+qHlTVfuAJ4Go//r6QsWFvMyJw/kwrBGZ07ji/EIAH36lyOIkJRv4sBDnAyZc91vqeO9V1IrJDRP4kInnDvZCI3CkipSJS2tzc7I+sAeXtvc0syk0hNSHa6SgmSOROjueqJVN5fPNh2rr6nY5jgozTncXPAwWqugh4FXh4uJ1U9QFVLVbV4oyM0P6W3N7dz/aadmsWMmP25Qun0zMwZJPRmTHzZyGoA07+hp/re+4EVW1V1T7fwweB5X7MExTe3d+CR23YqBm7mVlJfHJeFg+/X01X36DTcUwQ8Wch2ALMFJFCEYkGbgTWn7yDiGSf9PAqYI8f8wSFDZXNJMdFsTg32ekoJgh9+aLpdPQM8LgtXGPGwG+FQFUHgb8D/oL3A/6PqrpbRH4oIlf5dvu6iOwWkTLg68Bt/soTDFSVDXub+cTMdJtWwpyVZfmTWV2Uxv1vH6R3YMjpOCZI+PXTRlVfUtVZqjpdVf/F99wPVHW97/7/UdX5qrpYVS9W1Qp/5gl0O2o7OOLu4+LZmU5HMUHsG2tn0uzu49GNh5yOYoKEfe0MIC/vaiTSJayda4XAnL1VRWmsmZHGrzYcoLvf+grMyKwQBAhV5ZVdDayenkZKvA0bNefmW2tn0XKsn0c+sLMCMzIrBAGisslNdWs36xZMcTqKCQHFBalcMCuD+zcc4JiNIDIjsEIQIF7e2YiId455Y8bDtz85i6PdAzz0nl1tbM7MCkGAeGVXIyumpZKZFOt0FBMiluSlsHZuJvdvOEjrsb6Rf8CELSsEAeBg8zEqm9zWLGTG3d2fnkP3wBD/8dpep6OYAGaFIAC8srsRwAqBGXczMpO4pSSfxzYdprLR7XQcE6CsEASAV3Y1sjg3makpcU5HMSHom2tnkRgTyT+/WI6qOh3HBCArBA6raetmR20H6xZkj7yzMWdhckI031g7i3f2tfBWZejP3mvGzgqBw57b5p2H7zOLrRAY/7l11TQK0xP40QvlNvWE+RgrBA5SVZ7dVkdJYSq5k+OdjmNCWHSki3uums/Bli5++eZ+p+OYAGOFwEE7ajs42NLFZ5cOt16PMePrwlkZfHZpDvdtOEBFY6fTcUwAsULgoGe21hId6eLTC61ZyEyMf7xyHpNio/jWk2X0DVoTkfGyQuCQ3oEhnt1Wx2Xzp5AcF+V0HBMmUhOi+cl1i9jT0MlP/9uuLTBeVggc8tLOBjp7B7lp5bDLNBvjN2vnZXFzST4PvH2Q18qbnI5jAoAVAoc8vvkwBWnxrC5KczqKCUM/uHIeC3Im8a0/bqeqpcvpOMZhVggcUNnoZkv1UW5cmY+IOB3HhKHYqAju+9xyIlzC7Q9toa2r3+lIxkFWCBzwu/eqiIl08dfF1ixknJOXGs+Dny+mrr2HOx7eYgvehzErBBOs9Vgfz2yr49pluaQm2AI0xlnFBance8MStte0c/tDW2xFszBlhWCCPbbpMP2DHm5fU+B0FGMA+PTCbP7jhiVsqW7jcw9usmaiMGSFYAJ19Q3yu/eruWh2BjOzkpyOY8wJVy/J4ZefW8bu+k6uu+999h+xmUrDiRWCCfToxkO0dfXztUtmOh3FmI9ZtyCbx+4owd07wFW/eI9nttbabKVhwgrBBOnuH+SBtw9y/sx0lk+b7HQcY4ZVXJDKC187n/lTJ/HtP5Zx5+8/pPZot9OxjJ9ZIZggD7x9kNaufr651s4GTGCbkhzLE3eu5ruXz+Gdfc1c+tMN/PjlClpsucuQFel0gHDQ0NHDrzYc4IqF2Syflup0HGNGFOES7rxgOlcsmsq/vVLB/W8f4HfvVXHZ/ClcuyyHT8xIJzLCvkeGCisEE+BfX6rAo971Y40JJjkpcdx741K+fulMHnqvmud31LO+rJ70xGjWzEhnVVEaJYWpFKYn2MWRQcwKgZ+9Wt7E+rJ6vnHpTPJSbc0BE5ymZyTyo2sW8P0r5/JmRTMv7mzgvf2t/Hl7PQCT46NYnJfC4twUluR7/7XrZIKHFQI/OtrVz3ef3cnc7El89eIZTscx5pzFREawbsEU1i2YgqpyoLmLzVVtbK85SllNBxv27uP4QKNpafGcNz2di2dnsGZGOgkx9nETqOyd8ZPBIQ9ff2IbHd0DPPTFFURHWnuqCS0iwozMRGZkJnJzST4Ax/oG2VnbQVltOx8eOsrzZfU8vvkw0REuLpiVwbXLcrhkTiaxUREOpzcns0LgB6rKv75cwTv7WvjJdQuZPzXZ6UjGTIjEmEhWT09j9XTvrLr9gx5KD7Xxxp4jrC+r57U9TUyKjeSKRdl8dmkuKwomW99CAJBgu2CkuLhYS0tLnY5xRv/x6l7ufX0fX1g9jX+6eoHTcYwJCEMe5f0DLTy7tY5XdjfS3T9Efmo81y7L4bpludaH5mci8qGqFg+7zQrB+Bkc8vAvL+3hd+9V81fLc/nJdYtwuezbjjGn6u4f5JVdjTy9tZb3D7SiCisLUrlueQ6XL8wmKdZW7RtvVggmwOHWbv7X02VsPNjG7WsK+d4Vc4mwImDMiOrbe3h2Wx1Pf1jLwZYuYiJdnD8znbVzs7h0bhYZSTFORwwJVgj86GhXPw++e5DfvFtFpMvFPVfN5/rluU7HMiboqCrbatpZv72eV8ubqGvvAWDOlCRWFaWxqiiVRbkpZCfHWr/CWXCsEIjIOuBeIAJ4UFV/fMr2GOARYDnQCtygqtVnes1AKARHOnvZWNXGa+VN/GV3I/1DHq5YmM13L5/L1JQ4R7MZEwpUlYpGN29UHGHjwVa2VLfRO+ABvNcszJ+azPypk5iZlUROShw5KXFMSY610Xln4EghEJEIYC/wSaAW2ALcpKrlJ+3zFWCRqt4lIjcCn1XVG870uuNVCFQVj3o7sIY8ypB6/x0c8tDVN0Rn7wCdvQO4ewdpOdbH4dZuDrd1U9HoPrHGa3JcFFctnsqtq6cxy6aVNsZv+gc97KzroLy+g931neyu76Sy0U3/kOfEPiKQkRhDSnwUCTGRJMZEkhAdSXx0BAgIggiIb19BcLkABJd4n3OJ+LaL977g2yYf2X58m3c/32v5XkNEiHAJ0REuoiO9t5gTt4gTj/9n20efi4l0ER3hGveznjMVAn8OH10J7FfVg74QTwBXA+Un7XM1cI/v/p+AX4iIqB+q0yu7Gvjmk9vxeDjxoT8W0REuclPjvGOmV+ZTUpTKvOxJNt+KMRMgOtLF8mmTPzJz78CQh9qjPdS391DX3kOd735n7wBdfUO4ewdp7OilZ2DoxEVuqooCqqB4vwx6tx2/7/3X490Bj29/j6r3Z4Z5zl8iXd5ixEnF62/OL+I7n5o9/r9r3F/xf+QANSc9rgVKTrePqg6KSAeQBrScvJOI3Anc6Xt4TEQqfffTT93Xn/YBbwIP+v9XTehxTZBQPCYIzeMKxWOCEDiuv/fdTjKWY5p2ug1BcUGZqj4APHDq8yJSerpTnWAWiscViscEoXlcoXhMEJrHNV7H5M92jTog76THub7nht1HRCKBZLydxsYYYyaIPwvBFmCmiBSKSDRwI7D+lH3WA1/w3b8eeMMf/QPGGGNOz29NQ742/78D/oJ3+OhvVXW3iPwQKFXV9cBvgN+LyH6gDW+xGIuPNReFiFA8rlA8JgjN4wrFY4LQPK5xOaagu6DMGGPM+LKxj8YYE+asEBhjTJgLqkIgIqki8qqI7PP9O3mYfZaIyAcisltEdojIGa9UdpKIrBORShHZLyJ3D7M9RkSe9G3fJCIFDsQck1Ec07dFpNz33rwuIqcd2xwoRjqmk/a7TkRURIJiiOJojktE/tr3fu0WkccmOuNYjeLvL19E3hSRbb6/wcudyDkWIvJbETkiIrtOs11E5Oe+Y94hIsvG/EtUNWhuwL8Bd/vu3w38ZJh9ZgEzffenAg1AitPZh8kZARwAioBooAyYd8o+XwF+5bt/I/Ck07nH4ZguBuJ9978cCsfk2y8JeBvYCBQ7nXuc3quZwDZgsu9xptO5x+GYHgC+7Ls/D6h2OvcojusCYBmw6zTbLwdexnsB8ipg01h/R1CdEeCdkuJh3/2HgWtO3UFV96rqPt/9euAIkDFRAcfgxBQcqtoPHJ+C42QnH++fgEslsKddHPGYVPVNVe32PdyI9/qSQDaa9wngR8BPgN6JDHcORnNcfwP8l6oeBVDVIxOccaxGc0wKTPLdTwbqJzDfWVHVt/GOqjydq4FH1GsjkCIi2WP5HcFWCLJUtcF3vxHIOtPOIrIS7zeDA/4OdhaGm4Ij53T7qOogcHwKjkA1mmM62ZfwfpMJZCMek+9UPE9VX5zIYOdoNO/VLGCWiLwnIht9swkHstEc0z3ALSJSC7wEfG1iovnVWP/ffUzATTEhIq8BU4bZ9L2TH6iqishpx776KuLvgS+oqud0+xlniMgtQDFwodNZzoWIuICfAbc5HMUfIvE2D12E98ztbRFZqKrtToY6RzcBD6nqT0VkNd7rmBaE+2dEwBUCVV17um0i0iQi2ara4PugH/ZUVUQmAS8C3/OdKgWisUzBURskU3CM5pgQkbV4C/uFqto3QdnO1kjHlAQsAN7ytdpNAdaLyFWqGjgrKH3caN6rWrztzQNAlYjsxVsYtkxMxDEbzTF9CVgHoKofiEgs3onbAr3Z60xG9f/uTIKtaejkKSm+APz51B1801k8i7fN7E8TmG2sQnEKjhGPSUSWAvcDVwVBmzOMcEyq2qGq6apaoKoFePs9Ar0IwOj+/p7DezaAiKTjbSo6OIEZx2o0x3QYuBRAROYCsUDzhKYcf+uBz/tGD60COk5qQh8dp3vEx9h7nga8jndG6NeAVN/zxXhXQAO4BRgAtp90W+J09tMcz+V4F+85gPfsBeCHeD9IwPtH+hSwH9gMFDmdeRyO6TWg6aT3Zr3Tmc/1mE7Z9y2CYNTQKN8rwdvsVQ7sBG50OvM4HNM84D28I4q2A59yOvMojulxvKMfB/CepX0JuAu466T36b98x7zzbP7+bIoJY4wJc8HWNGSMMWacWSEwxpgwZ4XAGGPCnBUCY4wJc1YIjDEmzFkhMMaYMGeFwBhjwtz/B5/J5FRAZE4SAAAAAElFTkSuQmCC\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYwAAAD+CAYAAAAppDI0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAzy0lEQVR4nO3deXhTdb4/8He2bumebnTfN9IlXaAUKMvIosVdEXtFHRZ11Ko/oXdwu6MwzKBlwKHOhRmKCxcURYUCFQUFZC1toVBa2gLd6Ub3Jt2bnN8fhUrtlpQkJ0k/r+fJ05KcJO/zAHnnnO8538NhGIYBIYQQMgYu2wEIIYToByoMQgghSqHCIIQQohQqDEIIIUqhwiCEEKIUKgxCCCFKocIghBCiFL623ig5ORknTpxATU0NzMzMEBcXh6SkJNjY2Iz4nLlz56K+vh58/m8xN23ahDlz5ij1ngEBAfecmxBCJpqioqJh79daYfB4PCQnJ8PPzw9tbW1ISkrCW2+9hW3bto36vA8++ACPPfbYuN93pBUnhBAy1GhftLW2S+rNN99EcHAwBAIBRCIRli5diszMTG29PSGEkHvE2hjGuXPnEBgYOOZyycnJmDJlChYtWoTt27ejt7dXC+kIIYT8ntZ2Sd3thx9+wN69e7Fr165Rl9uwYQOCg4NhYmKC3NxcJCUloaWlBUlJSUOWTUlJwSeffKKpyIQQMuFxtD35YHp6Ot5//32kpKQgJiZGpeempaUhOTkZp0+fVmr5gIAAGsMghBAVjPa5qdUtjL179yI5ORnbtm1DZGSkys/ncukoYEIIYYvWCmPnzp3417/+hR07diAkJGTM5cvKylBfX4/Q0FAIBALk5eVhy5YtiI+P10JaQgghv6e1wli/fj34fD6effbZQfenp6fD2dkZ1dXViI+Px/bt2xEVFYW2tjasW7cOlZWV4HA4cHR0xOOPP47ly5drKzIhhJC7aH0MQ5toDIOMpqdXjuqGdhjxuXASCcHlctiORAjrdGYMgxBd0NHVi90/FeKXrEq0d/Yfpu1ib44l8wMwO8KV5XSE6C4qDDKhlNe24W+fZYLP5+K1xeGICHBAZ08fjp6vQMo3l1Ba1Yrn4oNpa4OQYVBhkAnjVlMH/uffZxHqZ49XnwyHsYAHADAx5mPxff4I9bXD2h3nweVy8Fx8MMtpCdE9dJwqmRCkHT14P/UcfF1t8MZTkoGyuFugpy3e+eMU7P/1Bs5dqWEhJSG6jQqDGLyeXjn++ul5mBkLkLQ0EjzeyP/sJ3uL8PyiyfjnnotobuvSYkpCdB8VBjFocgWDf3x5AS3Sbry3fCpMjMbeC/vgDG+4O1ni00P5WkhIiP6gwiAGi2EYpKZdwdWSJnzwwjRYmRsr9Twul4M/PR6KUzlVuHKjQcMpCdEfVBjEYO07cQM/Z1bgLyti4CQSqvRcL2cr3D/NE5+n58OAT1UiRCV0lBTROoZh0CztRmWtFHXNHWhr70GfXAE+jwtrcyO4OlrAy9lq2IFpZR3LrsT/HS7Au8umwtfNelyvsfg+f6z428/IzK/FVPGkcWchxFBQYRCNk8sVKK5qxeXr9ci93oDrN1vQ3tkLEyMenERCWAqNwOdz0denQLO0C9X17eByOQjxscOsCBdMD3NRqTyOZVdgy9eX8NpTEkQGOo47t42lCR6c4YVdPxYiOtiJzs0gEx4VBtGYxtZOHDhZgmMXKiFt74G/uw1C/ezw8CwfuDtawM7adNgP4Z5eOa5VNON8fi0+O3gV/9mfh7lRblgw1QMekyxHfD+5gsFXPxXi22PX8foSCeZEut3zOjw2xw+HzpTiQmEdooOd7vn1CNFnNJcUUbvePgX2HC3C/hM34OVihQdivRAjdoKZiWBcr5WZX4sfz5Xh8o16+LpaY94Ud0yZ7ASRlSmA/oK5WHQLXx8tQkNrF5KeiUSor73a1uc/+6+gpKoVG16ZobbXJERX0VxSRGvqmzvxt8/Po0XWgzXPRSMqyBEczvh35Qj4XEwPc8b0MGfUNXXgWFYFvj12Hf/7XS6szY1hZMRDU2sneDwu7p/micfn+MHaQrmjoZT1cJwPXvj7zygsa0Kgp61aX5sQfUKFQdSmtrEd72w7CzcHc6x7MRbmZkZqfX1HWzM8vSAQS+YHoK6pAxW1UvT0ySGyNIWPqxWM7mGQfKz3nRHqjLSTxVQYZEKjwiBqIevsxf/8+xx8XKyQ9EwUBHzNHbHN4XDgJBKqfKjsvYif4YW3//cMmtq6YGtporX3JUSX0HkY5J4pFAw+/uoihKZ8rP6vSI2WBVuCPG3h7mSBnzLK2Y5CCGsM73820bqfzpcjr6QRa56borHdQmzjcDiIn+6FH8+VoU+uYDsOIaygwiD3pFXWjZ3pV/F8fDAcbc3YjqNRsySu6O7pw/m8WrajEMIKKgxyT/7vcAEm2Qkxb6oH21E0zsSYjz9McccPZ0vZjkIIK6gwyLjVNrbjaGYFVj4cAt4EOQs6PtYLV4obUFHbxnYUQrSOCoOM27fHrkPsLUKQ18Q51NTZ3hzhfvY4fLaM7SiEaB0VBhmXhpZO/JJVgafm+bMdResWTvPE8QuV6OrpYzsKIVpFhUHG5fC5Mng5WyHEx47tKFo3ZbITBAIezlyuZjsKIVpFhUFU1idX4OfMcjwQ63lP037oKz6Pi3lT3OmcDDLhUGEQlWVdrUNXjxwzwlzYjsKa+VM9UFjehHIa/CYTCBUGUdlPGWWYHeEKE+OJO7OMk0iIMD97HKGtDDKBUGEQlbTKupFTdAt/iHZnOwrrFsZ44lh2Jbp75WxHIUQrqDCISs7mVsPB1gx+47zsqSGZMtkJfB4XZ3Np8JtMDFQYRCWnL1djRpjLhBzs/j0Bn4s/RLvR4DeZMKgwiNKa27qQV9yAmeETd7D79+ZP9UB+SSMq66RsRyFE46gwiNLO5dXASSSEl/PI19WeaJztzRHqa4cj52krgxg+KgyitKyrdZgy2Yl2R/3OwhhP/JJViR4a/CYGjgqDKKW7V47c6/WIDnZkO4rOiQlxAocDnLtSw3YUQjRKa4WRnJyM+Ph4REREYMaMGXj77bfR3Nw86nMqKyuxfPlySCQSxMbGYvPmzWAYRkuJyd2u3GgAj8dFkKeI7Sg6R8Dn4Q/RdOY3MXxaKwwej4fk5GScP38eaWlpqK2txVtvvTXi8nK5HC+99BKcnZ1x+vRp7Nq1CwcPHsSnn36qrcjkLllXayEJsDfIy6+qw4IYD1wpbkBVvYztKIRojNb+97/55psIDg6GQCCASCTC0qVLkZmZOeLy2dnZKC8vR1JSEoRCIby9vbFixQp8+eWX2opMbmMYBtmFtxAdRLujRuJibw6xj4i2MohBY+3r4rlz5xAYGDji44WFhfDw8ICl5W9H5IjFYty8eRMyGX2L06baxg7cauqAJMCB7Sg6bUGMJ37JqkBvHw1+E8PESmH88MMP2Lt3L955550Rl5HJZLCwsBh0353yGK4wUlJSEBAQMOhG1CP3Rj1c7M0hsjJlO4pOiw2ZBIZhkEHX/CYGSuuFkZ6ejr/85S/YunUrJk+ePOJy5ubmQ4qhra1t4LHfS0xMRFFR0aAbUY/c6w0I9Zt4171QlZGAh7lR7vgpo4ztKIRohFYLY+/evfjggw+wbds2xMTEjLpsYGAgysvLIZX+dgZtfn4+XF1dhy0MohkMwyD3RgPCfO3ZjqIXFsR44PL1BlTT4DcxQForjJ07d2Ljxo3YsWMHIiMjx1w+KioK7u7uSE5ORkdHB0pLS5Gamoqnn35aC2nJHRV1UrTIuiH2ocNpleHmaAGxjwiHz5WxHYUQtdNaYaxfvx4ymQzPPvssJBLJwK26un+mz+rqakgkEmRnZwPoPwx327ZtqKqqQmxsLBISErBo0SIsX75cW5EJ+s+/8JxkCStzY7aj6I346V44mllB1/wmBkdrV8AZa0zB2dkZOTk5g+5zc3PDjh07NBmLjCG/pBFib9q6UEWMeBK278/DrxersCDGg+04hKgNnYVFRsQwDK6WNiHYiwpDFXweFwuneeKHM6U0MwExKFQYZES3mjvR1NaFIC9btqPonQUxHiivbUNh2ejT3xCiT6gwyIgKShvhYGMKO2s6/0JVtpYmiA11xqEzJWxHIURtqDDIiK6WNtFkg/cgfroXzuZWo1naxXYUQtSCCoOM6GppI4K9aXfUeAV72cLVwQJHaH4pYiCoMMiwOrp6UVEnRZAnFcZ4cTgcxE/3wo/nyiCXK9iOQ8g9o8Igwyq+2QoBjwt3R4uxFyYjmh3his7uPpzPp/mliP6jwiDDul7ZAm8XK/B49E/kXpgY8/GHaHeknyllOwoh94w+DciwbtxsgZ+7DdsxDMID071wpbgBFbVtbEch5J5QYZBhXa9shq+rNdsxDIKLvTnC/ezxw9kytqMQck+oMMgQ0o4e1DZ2wM/Nmu0oBiN+uheOZVego6uX7SiEjBsVBhniRmULTI15cLanaeTVJSrYCRZmRjieXcl2FELGjQqDDHHjZgu8XazB43LYjmIweFwOFk7zRPpZml+K6C8qDDLE9coW2h2lAfOneqC2sQNXihvYjkLIuFBhkCGoMDTDytwYM8Nd6BBboreoMMggzdIuNLR0wpcKQyPuj/XE+bxatEi72Y5CiMqoMMggxTdbITQVYJJIyHYUgxTgboNJdkKcuEiD30T/UGGQQa5XNMPP1RocDg14awKHw8F90e74ObOCBr+J3qHCIINcv9lCu6M0bHakKyrrpLhxs4XtKISohAqDDGAYBjcqqTA0TWRlCkmAA05cuMl2FEJUQoVBBjRLu9Es7YaPixXbUQxenMQVpy5VQa6g3VJEf1BhkAFlNW0wNebD0daM7SgGL0bshPbOXuTdoHMyiP6gwiADymva4OFkQQPeWmBmIkD0ZCf8mkO7pYj+oMIgA8pq2uAxyZLtGBPGLIkLzl6pQR9djY/oCSoMMqC8tg2eVBhaExHoiD65AldotxTRE1QYBAAgVzCorJXSFoYWGQt4iAx0wLkrNWxHIUQpVBgEAFDTIENPn4K2MLRsWogzzuXV0NFSRC9QYRAAQHmNFLaWJrAwM2I7yoQSHeQIWUcPisqb2I5CyJioMAiA/gFv2rrQPqGpAKF+9sjIq2U7CiFjosIgAPoHvGn8gh1TghyRXUCFQXQfFQYBcGcLw4LtGBNSVLATKutkqG1sZzsKIaNSqTAuXLigqRyERV09fahtbIe7E21hsMHR1gxujhbILqhjOwoho1KpMJ555hksWrQIO3fuRGtrq6YyES2rrJOCA8DNkbYw2BId5IgsKgyi41QqjKNHj+K+++7Djh07EBcXh9WrVyMrK0vp56enpyMhIQEREREICAgYc/m5c+ciJCQEEolk4Hb8+HFVIhMllNe0YZKdOYwFPLajTFhRwY64cqMB3b1ytqMQMiKVCsPV1RVvvPEGjh8/jo8//hgdHR344x//iIULF+Kzzz5DU9PohwZaWloiISEBb7/9ttLv+cEHHyAnJ2fgNmfOHFUiEyWU1UjpCCmWBXrYgsvloKC0ke0ohIxoXIPeXC4Xc+bMQUpKCt566y1UVVXhww8/xOzZs/Huu++iubl52OfNnDkTixYtgpub2z2FJupVTnNIsU7A50LsLcKla/VsRyFkROMqjIqKCvzjH//ArFmz8PHHH+PJJ5/E/v37kZKSgqKiIrzyyitqC5icnIwpU6Zg0aJF2L59O3p7e4ddLiUlBQEBAYNuRDlltXSElC4I87PHZZpXiugwvioLp6en45tvvkFmZiYmT56MN954A/Hx8TA1NQUABAYGwsfHBwsWLFBLuA0bNiA4OBgmJibIzc1FUlISWlpakJSUNGTZxMREJCYmDrqPSmNsrbJutEi7aQtDB4T52eOzQ/mQdvTQGfdEJ6m0hfHee+/Bw8MD3333Hb799ls88cQTA2Vxh52dHf70pz+pJdyUKVNgbm4OPp+PiIgIvPbaa0hLS1PLa5N+ZTVtMDbiwclWyHaUCc9zkiUszIxo9lqis1Tawjh16hSEwtE/WExMTPDqq6/eU6iRcLl0nqG6lde0wd3RAlwuXTSJbVwuB6G+drh8vR6xoc5sxyFkCJU+gaOiotDYOPQojubmZgQFBY35fLlcju7u7oFxiO7ubnR3d0OhGHoBmbKyMmRlZQ08npubiy1btiA+Pl6VyGQMNIeUbgn3t8fl6zTwTXSTSoXBMMNPwdzb2wseb+xj+NPS0hAaGorly5cDAEJDQxEaGoqsrCxUV1dDIpEgOzsbANDW1oZ169YhJiYGUVFR+POf/4zHH38cq1evViUyGQPNIaVbwvzsUVXfjvrmTrajEDKEUruk9u/fDwDgcDg4fPgwzM3NBx6Ty+U4f/48PDw8xnydxx57DI899tiIj+fk5Az8HhoaigMHDigTj4yTQsGgolYKT5oSRGc4iYRwsDXD5ev1uG+KO9txCBlEqcJ45513Bn7/+9//PugxgUAAV1dXrFmzRr3JiMbVNXWgq0dOWxg6JtzPHpdvUGEQ3aNUYeTn5wPon6rj22+/ha2trUZDEe0or22DtbkxrC2M2Y5C7hLmZ4fUtDwwDAMOhw5GILpDpTGMY8eOUVkYkPKaNrg70Ql7uibE1w7N0m7cvCVjOwohg4y5hXHw4EEsWLAARkZGOHjw4KjLPvjgg2oLRjSPjpDSTTYWJnB1MEdeSSPNIEx0ypiFkZSUhNjYWIhEomHPsL6Dw+FQYeiZ8to2SAIc2I5BhiH2sUNecQPun+bJdhRCBoxZGIWFhcP+TvRbb58cVfXttIWho8TeInx6MJ/GMYhOoVOnJ6jKOhkYhoE77fLQSWIfEZraulBDl20lOkSlwjhz5sygy7R+8803ePzxx7FmzRrIZDRAp0/KatrgZCuEibFKs8MQLRFZmWKSnRB5xXR9DKI7VCqM5OTkgWtdlJaWYu3atRCLxcjLy8NHH32kkYBEM/qvgUFbF7pM7C1CXjFNREh0h0qFUVFRAX9/fwD9l2udNm0aPvjgA6xbtw4nTpzQRD6iIWU0JYjOE/vYIa+EtjCI7lB5DOPOAFxWVhamT58OAHB0dERLS4tagxHNKqdDanWe2EeE+uZO1DV1sB2FEAAqFkZAQAC+/PJLZGVlISMjAzNmzAAA1NTU0Al9ekTW0YPG1i540BxSOs3BxgwOtma0W4roDJUKY9WqVfj+++/x7LPP4pFHHoGvry8A4Pjx4wgJCdFIQKJ+ZTVtEPC5cLajiybpOrG3CPm0W4roCJUOkYmKisLZs2fR3t4OS8vfvp0uXrx4yJX3iO4qr5XCzdECPB4dVa3rQnxE+Obn62zHIATAOMYweDzeoLIAAHd3d9jb26stFNEsGr/QH2IfO9Q0tqOxla6PQdin0haGQqHAvn37cPbsWTQ2Ng65Ut7OnTvVGo5oRllNG2LEk9iOQZTgaGsGOysTXCluxOwIV7bjkAlOpcL48MMPsXv3bkybNg0uLi40ZYEeYhgGFbVtWDIvgO0oRAkcDmdgXikqDMI2lQrj0KFD2LhxIxYuXKipPETD6ls60d7VRyft6RGxjwj7ThSzHYMQ1cYw+vr6EBwcrKksRAvKa9pgbiqAraUJ21GIksQ+dqiql6G5rYvtKGSCU6kwHnroIfz000+aykK0oKym/wxv2p2oP5zthLCxMKazvgnrVNolZWFhgdTUVOTk5CAoKAgCgWDQ4y+99JJawxH1K6+R0hFSeubucYyZ4S5sxyETmEqFsX//fgiFQhQWFg65NgaHw6HC0APltW14YLoX2zGIisQ+IqSfKWU7BpngVCqMY8eOaSoH0YI+uQI3b0nhSVOC6B2xtwhbv8tFq6wbVubGbMchE9S4T/Vtbm4GwzDqzEI0rOqWDH1yho6Q0kNujhawMjeiaUIIq1QqDLlcji1btiA6OhrTp0/HzZs3AQAbN27Enj17NBKQqE9ZTRscbExhZiIYe2GiUzgcDiZ7i2jgm7BKpcLYvn079u/fj3feeWfQgHdwcDD27dun9nBEvcrpGhh6TextRzPXElapVBj79u3D+++/j0ceeQRc7m9P9ff3R1lZmbqzETWjI6T0m9hHhLKaNsg6etiOQiYolQqjpqYGPj4+Q+7n8Xjo6qKTinRdWW0bXQNDj3k4WcLcVEDjGIQ1KhWGi4vLkMNpAeDs2bPw9vZWWyiifh1dvbjV1EFbGHqMy+Ug2IvGMQh7VDqsNiEhAevXr4excf9hfWVlZTh58iQ2b96MNWvWaCQgUY+KWin4PA6c7c3ZjkLugdjHDr9erGQ7BpmgVCqMpUuXoqWlBa+++iq6urqwcuVKGBsb48UXX8QTTzyhqYxEDUqqW+HuaAkBny6apM/EPiJ8djAP7Z29EJrS0W5Eu1QqDABITEzEE088gYaGBjAMA19fX5iZmWkiG1GjkqpWeLnQ7ih95+VsBVNjPgrKmhAV5Mh2HDLBKF0YTU1N2LhxI44ePQqZTAagf26p+fPn480334Stre2Yr5Geno7du3ejsLAQ7e3tKCoqGnX5yspKvP/++7h48SJMTU3x5JNP4o033qCJ88ahtLoVsyR0PQV9x+NyEOQlQl5xAxUG0TqlCqOzsxMJCQlobm7Gww8/DF9fXzAMg+vXr+PQoUO4ePEivv/+e5iYjD5ltqWlJRISEtDV1YV33nln1GXlcjleeuklREREYMuWLairq8OKFStgaWmJ5cuXK7+GBHK5AmXVbXh+kRXbUYgahPiIcDa3hu0YZAJSqjB2796N7u5uHDhwAI6Og7/VvPjii1iyZAm+/PJLLFu2bNTXmTlzJgDg/PnzY75ndnY2ysvL8dVXX0EoFMLb2xsrVqzAjh07qDBUVN3Qjp4+BbycqTAMgdjHDl/8UIDO7j6YGqu8V5mQcVNqBPTYsWN48cUXh5QFADg6OmLlypX45Zdf1BqssLAQHh4esLT8bb+7WCzGzZs3B3aJEeWUVLXCwdYM5jRIahB8XKxgLOCioKyJ7ShkglGqMEpKShAZGTni41FRUSguVu8lJGUyGSwsBk+Sd6c8hiuMlJQUBAQEDLqRfqXVrfB2pgFvQ8HjcRHkKaJpQojWKVUYMpkM1tbWIz5ubW2t9m/95ubmQ16zra1t4LHfS0xMRFFR0aAb6VdS1Qpv2h1lUMQ+IuQV0wl8RLuUKgy5XA4ejzfyi3C5kMvlagsFAIGBgSgvL4dUKh24Lz8/H66ursMWBhkewzAoqW6FlwsVhiERe9vhemUzunr62I5CJhClRswYhsHrr78+5JKsd/T29ir1ZnK5HH19fQPLd3d3AwAEAsGgyQyB/t1c7u7uSE5Oxpo1a1BXV4fU1FQ8/fTTSr0X6dcs7UarrIe2MAyMr5s1+DwurpY2ISLAge04ZIJQqjAeffTRMZdxdR37GP+0tDS89dZbA38ODQ0FAOzcuRNubm6Ij4/H9u3bERUVBR6Ph23btuH9999HbGwsTE1NsXjxYjpCSkUlVa0Qmgpgb2PKdhSiRgI+F2F+9sguqKPCIFrDYQz4snkBAQETfixj7y/XkFNUj7+9PJ3tKETNfsoox3fHruPfb/2BTmYlajPa5yZNLGTgaEoQwxUV5ICaxnZU1dNh5kQ7qDAMXP8htTR+YYhEVqbwdrFC1tU6tqOQCYIKw4B1dvehuqEd3nSElMGKDnZEdgEVBtEOKgwDVl7TBh6XA1cHi7EXJnopOsgR+SWNaO9U7khFQu4FFYYBu17ZAo9JdA0MQ+bnZgNzMwFyrt1iOwqZAOiTxIBdq2iGv7sN2zGIBnG5HEQGOtI4BtEKKgwDdq2iGf5uVBiGLjrYERcK66BQGOwR8kRHUGEYKGlHD6ob2uHvbs12FKJhEn8HyDp6ca2ime0oxMBRYRio65UtMDXmw4UGvA2e0FSAMH97nL5czXYUYuCoMAzU9Ypm+LlZg8elM4AngrhwF5y6VEW7pYhGUWEYqGsVLTTgPYHEiCehrb0H+aU05TnRHCoMA8QwDK5VNtP4xQQiNBUgKsgBp3Kq2I5CDBgVhgGqb+5Ei7SbtjAmmDiJK87kVqNPrmA7CjFQVBgG6FplM2wtTSCyoinNJ5LoIEf09MqRe50u3Uo0gwrDAPWPX1izHYNomYkxH1MmO+HXnJtsRyEGigrDANEZ3hPXLIkrMvJq0NOr3ksmEwJQYRgcuVyBGzfpCKmJShJgDw6HgyyawZZoABWGgam8JUNPrxy+rtZsRyEsEPB5mB3hiiPny9mOQgwQFYaBKSxrgquDOYSmArajEJYsiPFATtEt1DV1sB2FGBgqDAOTX9KIyd52bMcgLPJytoK/mw2O0lYGUTMqDAPCMAzyihsg9haxHYWwbEGMB45mlkNO52QQNaLCMCB1TR1oaO3CZCqMCW9muAs6u+U0+E3UigrDgOSXNMJJZAY7azphb6IzMeZjdqQrfsqg3VJEfagwDEhecSPENH5BblsY44kLhXW41UyD30Q9qDAMSP+AN+2OIv28Xazg52aNH8+VsR2FGAgqDAPR2NqJmsZ2iH2oMMhvHpzpgx/PlaGrp4/tKMQAUGEYiLziRthZmcDR1oztKESHTA91hoDPw4kLNL8UuXdUGAYi7/b5FxwOXWGP/EbA52LRDC8cOFUMhqGr8ZF7Q4VhIPJLGmh3FBnWghhP1DV2IKeonu0oRM9RYRiAFmk3KutkNOBNhmUpNMKcKDeknSpmOwrRc1QYBiC/tBHW5sZwdTBnOwrRUQ/N9EZO0S1U1knZjkL0GBWGAbh0rR4hvjR+QUbm7mQJSYAD9p24wXYUoseoMPQcwzC4WFiHyEAHtqMQHffEHD8cv1CJxtZOtqMQPaXVwlAoFNi0aRNiY2MhkUiwfPlyVFVVjbh8QEAAQkNDIZFIBm5FRUVaTKz7bt6S4VZzJyQBVBhkdGIfEXxcrbH/VxrLIOOj1cJITU3FoUOHsGvXLpw+fRrOzs546aWXoFCMPKPm9u3bkZOTM3ALCAjQYmLdd7HoFrydrWBracJ2FKLjOBwOnpjrhx/PlUHa0cN2HKKHtFoYe/bswYoVK+Dt7Q2hUIikpCSUlpbiwoUL2oxhUC4W3oIkwJ7tGERPTAl2gr2NGdLPlLIdheghrRWGVCpFVVUVxGLxwH2Wlpbw8PBAQUHBiM9btWoVpk6dikcffRTffPONNqLqje5eOfKKGxAZ6Mh2FKInuFwOnpjriwMnS9DVTdOFENXwtfVGMpkMQH9J3M3CwmLgsd/7/PPPIZFIwOVykZGRgdWrV6Ovrw8JCQlDlk1JScEnn3yi/uA6LK+4ATweB4GetmxHIXokTuKKXT8W4khmOR6a6cN2HKJHtLaFYW7ef46AVDr4OHCpVDrw2O9NmzYNJiYmMDIyQlxcHJ5//nkcOHBg2GUTExNRVFQ06GboLhbeQqivPQR8OtiNKI/P4+LRWb7Yd6IYvX10RT6iPK190lhYWMDFxQV5eXkD90mlUlRUVCAoKEip1+ByuTQfzl0uFN6iw2nJuMyb6o6eXjlO5tCkhER5Wv1qumTJEuzYsQOlpaXo6OhAcnIyPD09ERkZOWTZ/Px8XLlyBT09Pejr68OZM2fw2WefIT4+XpuRdVZtYzuq6mV0OC0ZFxMjPh6a6Y1vj12HQkFfwohytDaGAQArVqyAVCpFQkICOjs7ERkZia1bt4LL5SI7OxsrV65Eeno6nJ2dUVdXh+TkZNTW1oLH48HZ2RlvvPEGnn76aW1G1lkXi27BxV4IJ5GQ7ShET8VP98L3J27gzOVqzJS4sB2H6AEOY8D7eAICAgx2LON//n0Wns5WWPbgZLajED321U+FOHmpCp8kzQWPS1PLkNE/N2m0VA/JOnqQe6MBsSGT2I5C9NxDcT5olnbjFI1lECVQYeih8/m1sDI3hr+7DdtRiJ4Tmgrw6GwffHWkCHI5HTFFRkeFoYfOXalBbMgkcGkXAlGDB2d4Q9rRi+N0GVcyBioMPdPR1YuLRbcQG+rMdhRiIMxMBHh8ji/2HC2i8zLIqKgw9MyFglswNeYj2IvO7ibqEz/dC719chw+S3NMkZFRYeiZs1eqESOeBB6P/uqI+pgY87H0/mB8eaQIbe00ky0ZHn3q6JHuXjmyC+oQG0pHRxH1mxvlBieRGb76qZDtKERHUWHokZyiW+BxOQj1penMifpxuRyseEiMw+fK6NrfZFhUGHrk1KUqTJnsRJMNEo0R+9hhqtgJOw7kjb0wmXDok0dPdHT1IiOvFnMi3diOQgzcHxdNRu6NBmTk1bAdhegYKgw9cTa3BuamfIT60e4oollOIiGemuePbd/noqOrl+04RIdQYeiJExcrESdxpfl+iFY8NtsP5qYCfH7oKttRiA6hwtADt5o7kHujAXOjaHcU0Q4Bn4vXl0hwNLMc2QV1bMchOoIKQw8cPV8BH1dreDlbsR2FTCB+bjZ4en4g/rknB83SLrbjEB1AhaHj5AoGP2eWY2GMB9tRyAT0+Fw/uDlaIPn/LtDkhIQKQ9ddLKxDe1cvZobTBW6I9vG4HCQtjURVvQyfp9N4xkRHhaHjfjhbhjiJK8xMBGxHIROUjYUJ3n4+Gj+cKUX66RK24xAWUWHosJu3pLhQWIcHZ3qzHYVMcAEetlj1X5HYnpaH05er2I5DWEKFocMOnCpBmJ89PJws2Y5CCGJDnfGnx0Pxj90XcOZyNdtxCAv4bAcgw2tr78Gx7EqseTaa7SiEDFgQ4wkFAyTvykZbRyjun+bJdiSiRVQYOirtZDEmiYSICHBgOwohg9w/zRMWZgJs+vIiqutleC4+GHyabn9CoMLQQdKOHhw8VYLXn5LQZViJTpoR5gI7a1Ns+CILReXN+H9PR2CSnZDtWETD6GuBDkr7tRgONqaYFkLXvSC6K9DDFh//v9mwFBrhtX8cx/fHb9AlXg0cFYaOaWjpxL5fi/FfC4No64LoPGsLY7zzxyl49clwpJ0sxisfHcPR8+VUHAaKdknpmC9+uIpADxvEiJ3YjkKIUjgcDmZFuGLKZCccOl2CL364is8OXUWcxAVzo9zg52YNDoe+/BgCKgwdkl/SiJM5Vdj8xiz6D0b0jqkxH0/+wR8Px/kg82otjmVXIinlFKzNjRHiY4cQXxGCvURwsTenrWc9RYWhI7q6+/DPPTl4aKY3vF1okkGiv4wEPMwIc8GMMBe0SLuRe6MeV4obse/EDXyy9zLMTPjwc7OGv7sN/N1tEOBuAxtLE7ZjEyVQYeiIz9Ovgsvl4Jn7g9iOQojaWFsYI07iijiJK4D+84uuVzbjWnkzrlW24Mdz5ZB29GCSSIjIQAdEBjkixNcOxgIey8nJcKgwdMCx7EocOV+ODa/MoP8oxKBZCo0QGeiIyEBHAADDMKhr6r/eS3ZBHT76v2wAQGzoJMyJcIPY144uGqZDqDBYdrW0Ef/aewkvPx4Kf3cbtuMQolUcDgdOIiGcRELMn+qB3j4FLl27heMXbmLtjgxYCI0wO8IVc6LcaIocHUCFwaLC8ia8vz0DD8/ywX1T6HoXhAj4XEQHOyE62Antnb04m1uNYxcq8d3xG/B1tcLcKHfESVxgZW7MdtQJicMwDMN2CE0JCAhAUVER2zGGdSa3Gpu/uoj4WC88vyiYjooiZBR1TR04fqESx7IqUd/SgaggR8yNckdUkCMEfDqdTJ1G+9ykwtCyjq5efJF+FUfOl2PFwyF4INaTyoIQJTEMg4KyJhzLrsSpS1VgGCAi0AExk50gCXCgLQ810JnCUCgU+Pjjj/Htt9+is7MTERERWLt2LVxchr+a3NWrV7F27VoUFBTAxsYGy5Ytw7PPPqv0++lSYXR09eLI+Qp8d/w6rIRGSFwcjgAPW7ZjEaK3enrlyL3RgPP5tcjMr0FTWzc8J1kixNcOQR628Ha1wiSRkM75UJHOFMZ//vMf7NmzB6mpqXB0dMSGDRtw6dIlpKWlgcsdvFkpk8kwf/58JCQkYOXKlSgoKMALL7yAtWvXYuHChUq9H5uFwTAMahrbkVfciNzrDcjIr4Gl0AhPzvXDfVM8aDOaEDViGAYVdVLk3WhAbnEDrlW0oKGlEyZGPHg5W8HL2RJOIiEcbMxgb2MKe2tTWJkbU5kMY7TPTa0Oeu/ZswcrVqyAt3f/FeSSkpIQGxuLCxcuIDp68HUfjhw5Ai6Xi5dffhlcLhfh4eF48skn8eWXXypdGOPV2ydHs7QbCgUDhYKB/PZPBXPX7woG3T1ytHf1oqOrF7LOPsg6e1Df3InaxnZUN7SjRdoNZzshxD52ePu5KQjzt6dDBAnRAA6HAw8nS3g4WSJ+Rv/nS6usG6XVrSipakVpTRsy8mpQ39KJxtYuKBQMOBzAxIgPU2MeTI35MDXmg8flAhyAc/s1ORwM7DLmcADunfvw22ODfg7cP/gxLofzu9f87Xc+jwsBnwsBnwcj/m+/C27/biTgQsDjQSC4/efbj/H53NvL8way4XYGS3MjjRyir7XCkEqlqKqqglgsHrjP0tISHh4eKCgoGFIYhYWFCA4OHrTlIRaLsXfvXo1n3fpdLo5mVoy6DI/LgZGAB6GpAEITPsxMBBCaCuBgY4oY8SQ4iYTwd7eGyMpU43kJIUNZmRsj3N8B4f6DrykjlyvQ2NaFFmk3Orv70Nndh67bP+UKBgwDMGAABlAwAHD7vtu/K5j+LRrmzk8AjOL2/bjr/rt+Km7vyFEwd173t/vlcgbtnb3o6etGX58CPb1y9MoV6O1VoLdPgV65HD13fu+T3/6pgFwx8s6hGWHO+LMGLr6mtcKQyWQA+kvibhYWFgOP/X55CwuLQfdZWloOuywApKSk4JNPPhlyf0BAwHgjE0KIXrp2CPh0vfpfV2uFYW5uDqB/S+NuUql04LHfL9/Y2Djovra2tmGXBYDExEQkJiaO+P66NACuLoa4ToBhrpchrhNgmOtliOsEqGe9tDbyamFhARcXF+Tl5Q3cJ5VKUVFRgaCgofMnBQYG4urVq1AofptXPz8/H4GBgVrJSwghZDCtHqqzZMkS7NixA6Wlpejo6EBycjI8PT0RGRk5ZNn58+dDLpdj69at6OnpQW5uLvbu3Yunn35am5EJIYTcptXCWLFiBe6//34kJCQgNjYWVVVV2Lp1K7hcLrKzsyGRSFBdXQ2gf5dUamoqTp48iaioKCQmJuKVV17B/fffr83IhBBCbtPqYbVcLherVq3CqlWrhjwWFRWFnJycQfcFBwfj66+/Vst7v/rqq2p5HV1iiOsEGOZ6GeI6AYa5Xoa4ToB61sugpwYhhBCiPnS6MSGEEKVQYRBCCFGKwRbG559/jtmzZyMsLAxLlixBYWHhiMuWlpbitddew8yZMyGRSPDAAw+obezkXigUCmzatAmxsbGQSCRYvnw5qqqqRlz+6tWrWLJkCcLCwjB79mzs3LlTi2mVo8o6Xbp0CS+88AJiY2MRERGBRx99FEeOHNFyYuWo+nd1R15eHiZPnoylS5dqIaVqVF2nrq4ubNiwAXFxcQgPD8e8efPw66+/ajGxclRdrwMHDuDBBx9EREQE4uLisH79evT09Ggx8ejS09ORkJCAiIgIpU5UrqysxPLlyyGRSBAbG4vNmzdD6ZEJxgAdOnSIiY6OZnJycpiuri4mJSWFmT59OiOVSodd/tKlS8yuXbuY2tpaRqFQMJmZmUxERATz448/ajn5YP/+97+ZOXPmMMXFxYxMJmPeffddZtGiRYxcLh+yrFQqZaZNm8akpKQwXV1dTE5ODhMdHc0cPnyYheQjU2WdTpw4wezbt49pbGxk5HI58+OPPzJisZi5fPkyC8lHp8p63dHV1cUsWrSIee6555hnnnlGi2mVo8o6KRQKZtmyZcyyZcuYiooKhmEYpqamhqmsrNR27DGpsl4FBQVMYGAgc/jwYUahUDA3b95kFi5cyGzevFn7wUdw8uRJ5uDBg8zevXsZf3//UZft6+tjHnjgAebdd99lZDIZU1xczMyZM4dJTU1V6r0MsjCeeeYZ5qOPPhr4s1wuZ6ZPn87s27dP6ddITExk1q1bp4F0ypszZw6ze/fugT+3trYykydPZjIzM4cs+9133zHTp08f9I/+o48+YpYuXaqVrMpSZZ2G8+ijjzKffvqppuKN23jW6+9//zvz17/+ldmyZYtOFoYq63Tq1CkmJCSEaWxs1GbEcVFlvY4cOcJMnTp10H0bNmxgXnzxRY3nVFVGRsaYhZGRkcFMnjyZaW1tHbhv9+7dzNy5c5V6D4PcJVVYWDhokkMul4vg4GAUFBQo9fyOjg5cvnyZ1Xmoxpqs8fdGmqxxtF1x2qbqOv1eXV0dSkpKdO5s//GsV1ZWFo4fP44333xTWzFVouo6ZWRkwNXVFVu3bsX06dMxd+5crFu3Du3t7dqMPSZV12vGjBlwdXVFeno65HI5KioqcOzYMcybN0+bsdWmsLAQHh4eg+b0E4vFuHnz5ojz9N1NrwpjzZo1CAgIGPH22muvAeifuFDZSQ5/r6+vD6tXr4aLiwseeeQRTayGUjQ9WSMbVF2nu7W3tyMxMRFz5szBtGnTNJZxPFRdr/b2drz99tv461//ClNT3ZzNWNV1am5uRnFxMQDg559/xq5du5CTk4MPP/xQ82FVoOp6mZqa4oknnsBf/vIXhISEYN68eZBIJKx+NtyLkT4n7jw2Fq2euHev3nvvPfz3f//3iI8bGRkB6D9LfLhJDu3s7EZ9/Z6eHqxatQpNTU3Yvn07BALBvYceJ01P1sgGVdfp7sdfeOEF2Nvb69wHEKD6en344YeYNWvWkCn9dYmq6yQUCsHj8bB69WoYGxvD1NQUK1euxLp167B27VqtZFaGquu1b98+bNq0Cdu2bUNERAQaGhrw3nvv4c9//jM2btyolczqZG5uPqQY2traBh4bi15tYQiFQtja2o54u7PCgYGBgyY5VCgUuHr16rCTHN7R1dWFl19+GS0tLdixY8eQFtY2Q5ysUdV1Avq/uT733HOYNGkS/vnPfw58KdAlqq7X6dOnsX//fkydOhVTp05FamoqLl68iKlTp6KyslKb0Uek6joFBwcDwKDr0+vitepVXa+8vDxMnToVUVFR4HK5cHBwwOLFi/HLL79oM7baBAYGory8fFBh5ufnw9XV1fAKQ1lLlizB3r17kZubi56eHmzduhUAcN999w27vEwmw8qVK8EwDLZv3w6hUKjNuCMyxMkaVVmn+vp6LF26FAEBAdi4cSP4fN3dIFZlvb7++mscOnQIaWlpSEtLw5IlSyAWi5GWlgZnZ2cW0g9PlXWaN28eRCIRNm/ejJ6eHtTV1SE1NRULFixgIfnoVFmvyMhIZGZmIicnBwzDoLGxEd98882gMRC2yeVydHd3o7e3FwDQ3d2N7u7uQV8e74iKioK7uzuSk5PR0dGB0tJSpKamKv85cQ+D8jrts88+Y+Li4piQkBDmqaeeYgoKCgYeq6qqYsLDw5msrCyGYRjm+++/Z/z9/ZnQ0FAmPDx84LZ8+XK24jMM039018aNG5mYmBgmLCyMWbZs2cBhillZWUx4eDhTVVU1sHx+fj6zePFiJiQkhImLi2O++OILtqKPSJV1SklJYfz9/ZmwsLBBfy/vvfcem6swLFX/ru6mq0dJqbpO165dY5555hkmPDycmTlzJrN+/Xqmo6ODrfgjUnW9Pv/8c2bBggVMeHg4M23aNOb1119nqqur2Yo/xHfffcf4+/sPuWVkZAz5rGMYhqmoqGCWLVvGhIWFMTExMcymTZsYhUKh1HvRXFKEEEKUYpC7pAghhKgfFQYhhBClUGEQQghRChUGIYQQpVBhEEIIUQoVBiGEEKVQYRBCCFEKFQYhhBClUGEQQghRyv8H+YeTkBI/rjYAAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 432x288 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "needs_background": "light"
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -10268,16 +10287,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 302,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.2638835345994894"
+       "0.2638840499030476"
       ]
      },
-     "execution_count": 302,
+     "execution_count": 65,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10295,7 +10314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 308,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -10311,16 +10330,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 311,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "0.08920917476125206"
+       "0.08920894923457254"
       ]
      },
-     "execution_count": 311,
+     "execution_count": 67,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -10329,13 +10348,194 @@
     "_global_pearson(adata.layers['X_knn'].toarray(),\n",
     "                adata.layers['gene_score_knn'].toarray())"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Across genes for imputed ATAC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cors = Parallel(n_jobs=-1)(\n",
+    "    delayed(pearsonr)(\n",
+    "        adata.layers['X_magic'].toarray()[i],\n",
+    "        adata.layers['gene_score_cross_magic'].toarray()[i],\n",
+    "    )\n",
+    "    for i in range(adata.layers['X_magic'].shape[0])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:ylabel='Density'>"
+      ]
+     },
+     "execution_count": 69,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAD9CAYAAACm2+DgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAtQUlEQVR4nO3de3QTZf4/8HeSJmmbS++0pYUCxbaUaqUgl4JIXQX96qKCILrinRVWqu66/hbU73FxV1mV3eVsUVZXf678hK+KLCiCLn4VkQWEKixuC63KrRdo6SVpkjb3zO+P0NraAk2bzOTyfp2T03ZmMvlkTk/emed55hmZIAgCiIiIfkQudQFERBScGBBERNQnBgQREfWJAUFERH1iQBARUZ8YEERE1KcoqQvwl9zcXKlLICIKSdXV1X0uD5uAAM7/JomIqG8X+nLNJiYiIuoTA4KIiPrEgCAioj4xIIiIqE8MCCIi6hMDgoiI+sSAICKiPjEgQpjbI+BsawecLo/UpRBRGAqrC+UiyelmCx5b/QUsVicuzU7Gs0uKIZPJpC6LiMIIzyBC1HuffodRGXEo+3UJvq8zYPe/66UuiYjCDAMiBJ01dOCzr2px+8xcjEjX47ZrcvF/t1bC5nBJXRoRhREGRAj64IvjyM1KQEF2MgBg9vRs2B1uHKpukrgyIgonDIgQ9NXRRlw9YVjX38ooOcbnpaL8SIOEVRFRuGFAhJhWkw31TZaus4dOE8emovxoIzweQaLKiCjcMCBCTOWxFiTo1BiarOmxvCgvFaZ2B76vM0pTGBGFHQZEiPnP8WYUZCf3GtKqjVFi7MgkHKhkMxMR+QcDIsRUHGvBpdlJfa4bl5uC/xxrFrkiIgpXDIgQ0maxo7bR3Kv/oVNuVgK+r2uD280rq4lo8BgQIeRYXRtio6OQOUTb5/rRmfFwutyoaTSLXBkRhSMGRAipaTRheKruvFNqxEYrkTlEh29rDCJXRkThiAERQmoazBiepr/gNjnD4/FtjVGcgogorDEgQkhNgxlZaboLbpMzPIFnEETkFwyIECEIgreJ6WIBMSwBNQ0m2Oycl4mIBocBESKaDFZY7e6LNjFlpeshl8tx/HSbSJURUbhiQISImkYztDFKJOjUF9xOGSVH5hAtTjVwJBMRDQ4DIkTUNJiQla7v102BhqfpUNNgEqEqIgpnDIgQcarBjOGpF+5/6JSVpkcNzyCIaJAYECHidJMFGee5QO7HstJ0OMUzCCIaJFEDorm5GY899himTJmCCRMmYMGCBSgvL+9av3fvXsyePRuFhYWYNWsWtm/fLmZ5Qa2htQPpSZqLbwhvR3WbxQGj2R7gqogonIkaECtWrMDZs2exbds27N+/HzNnzsTPf/5zmEwm1NXVYcmSJVi4cCHKy8uxbNkyLF++HIcPHxazxKBks7tgNNuRmhjbr+2HJMRCrVLwLIKIBkXUgDh16hSuu+46JCYmQqFQ4LbbbkNHRwdqamqwefNm5OTkYN68eVCpVCgpKUFJSQnefvttMUsMSo2GDgDod0DI5TIMT2UzExENjqgBsWjRIuzYsQNNTU1wOp1Yv349RowYgZycHFRVVaGgoKDH9gUFBaiqquq1n7KyMuTm5vZ4hLPGlg7Ea9WIVkf1+znekUzsqCaigev/J44fjBs3Dlu2bMG0adOgUCgQHx+Pl156CSqVChaLBaNHj+6xvV6vh8Vi6bWf0tJSlJaW9lgWziHR0NKO1KT+nT10Gp6qx5cVZwJUERFFAtECwuPx4J577sGkSZNw4MABaDQafP7551i0aBHWr18PrVYLs7nnN16TyQSttn8jd8JZY2sH0hL710HdKXOIFqebe4crEVF/idbE1NbWhtraWtx1112Ii4tDVFQUrrnmGgwbNgx79uxBXl4eKioqejynsrISeXl5YpUYtBpaOnw+gxiaokGbxQFLhyNAVRFRuBMtIBISEpCdnY3169fDYrHA4/Hg008/xXfffYexY8fi5ptvRnV1NTZt2gSn04ldu3Zh586dWLBggVglBq2G1nak9bODulNakgZyuQz1TTyLIKKBEbUP4uWXX8YLL7yAa6+9Fna7HRkZGXj66acxadIkAMDatWuxcuVKrFixAmlpaXjuuedQWFgoZolBRxAENLb6fgYRpZAjLTEW9U3tyM1KDFB1RBTORA2IESNG4OWXXz7v+uLiYmzdulXEioKf0WKH3eH2uQ8CAIamaHGaZxBENECcaiPINbZ2QCGXISk+xufnZg7Roo4BQUQDxIAIck0GK5LioqGQX3wW1x/jGQQRDQYDIsi1tFmRPICzBwDISNHgdHM7PB7Bz1URUSRgQAS5ZqMNyXEDDQgt7A43Wtpsfq6KiCIBAyLINbdZB9T/AACJ+mhEqxRsZiKiAWFABLlmoxXJcdEDeq5MJkNakgZnWtr9XBURRQIGRJBrMQ68DwIA0pM1aGBAENEAMCCCmNvtQavZPqiA4BkEEQ0UAyKIGS12eDwCkgbYxAQA6UmxaGju8GNVRBQpGBBBrMlohUIuQ7xu4AHReQYhCBzqSkS+YUAEsRajDYkDvEiuU3qyBla7C6Z2zupKRL5hQASx5jbrgK+B6JQcHwO5XMaOaiLyGQMiiDUbrYPqfwC8s7oOSYjBmRb2QxCRbxgQQax5kENcO6UlcagrEfmOARHEWtpsSBpkExMApCdpcKaZAUFEvmFABLFWkw1J+sE1MQE8gyCigWFABClBENBq8o5iGqz05FgGBBH5jAERpNqtTjhdHiTo1YPeV1qSBq0mO2wOlx8qI6JIwYAIUq0m7xTdiYO4SK5TWpL3dqWNHMlERD5gQASpVpMNMeooRKsHf9vwGHUU4nVqzslERD5hQASpVpMdiX7ooO6Uzo5qIvIRAyJIGUw2vwZEalIsh7oSkU8YEEGq1WTzSwd1J+8ZBPsgiKj/GBBBqtXPZxC8LwQR+YoBEaQMZv/3QZxt7YDb7fHbPokovDEgglRrmw0J/jyDSI6F2yOgyWj12z6JKLwxIIKQIAhoNduQ6Mc+iHitGjFqBUcyEVG/MSCCkNXugt3h9msTk0wmQ2oiO6qJqP8YEEGo6ypqPwYEAKQlcU4mIuo/BkQQajXZoFYpEOOHq6i7S+NQVyLyAQMiCBlMdiTo1JDJBn4v6r6kJWnQ0MozCCLqHwZEEDJa7EjwwyR9P5aepEFDczsEQfD7voko/DAggpDBZEO8zn8jmDqlJcWi3eaCxer0+76JKPwwIIKQ0WIPSECkJMRCLgPnZCKifmFABCGD2Y4Erf8DQhklR3J8DO8LQUT9woAIQkazHfF+HuLaiR3VRNRfogfEgQMHcMcdd2DcuHGYOHEilixZ0rVu7969mD17NgoLCzFr1ixs375d7PKCgtFsQ3wAziCAc5P2sYmJiPrBvwPtL6K8vBxLlizB008/jZkzZ0Iul6OqqgoAUFdXhyVLluCpp57CTTfdhD179uDRRx9FRkYGCgsLxSxTUh6PAKPF4depvrtLS4rFv79tCsi+iSi8iHoG8cc//hHz58/H7NmzER0dDZVKhcsuuwwAsHnzZuTk5GDevHlQqVQoKSlBSUkJ3n77bTFLlJy5wwGPRwjsGQSvpiaifhAtIDo6OnD48GEAwJw5czBp0iTcdttt2LdvHwCgqqoKBQUFPZ5TUFDQdYbRXVlZGXJzc3s8woXRbAeAgIxiArxnEM1GK5wuTvtNRBcmWkCYTCZ4PB5s3boVv//97/Gvf/0Lc+fOxeLFi1FbWwuLxQK9Xt/jOXq9HhaLpde+SktLUV1d3eMRLoxmO2LUUYhWBab1Lz1JA0EAzho4komILky0gNBoNACAuXPnIj8/H0qlEvPnz0dmZiZ2794NrVYLs9nc4zkmkwlarVasEoOCwRyYi+Q6aWNV0MQoOWkfEV2UaAGh0+kwbNiwXss75xvKy8tDRUVFj3WVlZXIy8sTpb5g4Z1mI3ABAQDpSbFo4EgmIroIUTupf/azn2HTpk2orq6G2+3Gpk2bUF9fj+nTp+Pmm29GdXU1Nm3aBKfTiV27dmHnzp1YsGCBmCVKzmAKzFXU3aUmadDQyiYmIrownxq6v/76a4wfP37AL3bPPfegvb0d999/Pzo6OnDJJZfglVdeQWZmJgBg7dq1WLlyJVasWIG0tDQ899xzETXEFQjcRH3dpSXGou5s774dIqLufAqIO++8E9nZ2Zg/fz5uuukmxMXF+fRiMpkMS5cuxdKlS/tcX1xcjK1bt/q0z3BjNNuRnqwJ6GukJ2vwddXZgL4GEYU+n5qYPvnkE1xzzTV4/fXXMX36dPz6179GeXl5oGqLSAazLeB9EGmJGjS0cNpvIrownwIiMzMTjz76KHbu3InVq1ejo6MD9957L6677jq88cYbaG1tDVSdEcNotgfsIrlOacka2BxuGC32gL4OEYW2AXVSy+VylJSUoKysDMuXL0d9fT2ef/55zJgxA0899RQMBoO/64wIbo+AtgBN9d1dclw0FHIZZ3Ulogsa0NVYNTU12LhxIzZv3gy73Y558+Zh/vz5aGxsxJo1a/DQQw9hw4YN/q417JnbHfAICHgntUIhx5DEWJxubkfeiMSAvhYRhS6fAmLbtm149913ceDAAYwdOxaPPvoobrjhBsTExADwXsuQnZ2NWbNmBaTYcNfZ5BPoMwjA21HNWV2J6EJ8Coj//u//xo033ojf/OY3yM/P73Ob5OTkHlN4U/8ZTDZooqOgUioC/loZKVqcbuJQVyI6P58CYvfu3V1TZpxPdHT0eYex0oUF6lajfRmarMHREy2ivBYRhSafOqknTJiAlpbeHyoGgwFjxozxW1GRynsVdWD7HzoNTdHidDOHuhLR+fkUEOf7MHE6nVAoAt8sEu7EPoPosLk41JWIzqtfTUxbtmwB4L0S+qOPPuoxw6rb7cb+/fuRlZUVkAIjicFsQ0KAr4HolJIQiyiFHKeb2gM+aoqIQlO/AuLJJ5/s+n3lypU91imVSmRmZmLZsmX+rSwCGc12ZA4RZ3pzhVyG9ORYnGm2YOyoJFFek4hCS78CorKyEgBw9dVX47333kNiIsfOB4L3Kmrxvs0PTdaivolDXYmobz6NYvrss88CVQfBGxAJenGamIDOjmoOdSWivl00ILZu3YpZs2ZBpVJddKbVn/70p34rLNK4PQJM7YGfh6m7ockaHKrmrK5E1LeLBsTjjz+O4uJiJCUl4fHHHz/vdjKZjAExCCaLHR5BnKuoO2WcG+rq8QiQy2WivS4RhYaLBkRVVVWfv5N/dQ43DfRU390NTdHA4XSj1WRDcnyMaK9LRKFB1FuO0vkZzHZoYpRQRol3PUmiPhpqlYL9EETUJ58CYs+ePfj666+7/n733Xcxd+5cLFu2DBYLP2QGw2i2idr/AHibBYcmaziSiYj65FNAvPjii133ejhx4gSeeeYZFBQUoKKiAi+88EJACowUBpMdiXrxL1gbmsxJ+4iobz4Nc62pqUFOTg4A7+1Hp0yZghUrVuDQoUN45JFHAlJgpDCY7aL2P3QamqLBqTNm0V+XiIKfz30QMpl3tEt5eTmmTp0KAEhNTYXRaPRrYZHGYLYhXsRrIDoNTea1EETUN58CIjc3Fxs2bEB5eTm+/PJLTJs2DQBw5swZXl09SEazXZI5kTJStGhoaYfbw1ldiagnnwLisccewz/+8Q/cdddduPnmmzF69GgAwM6dO3HppZcGpMBIYTDbJGticrkFNBl4f2oi6smnPogJEyZg7969aG9vh16v71o+f/78rtuO0sAYTNKcQeg1Kmiio3C6qR1pSRe+GRQRRRaf+yAUCkWPcACA4cOHIyUlxW9FRRqnyw2L1SnqPEydZDIZhqZoUc+RTET0Iz6dQXg8HmzevBl79+5FS0sLPB5Pj/Xr1q3za3GRwmD2XkUt5jQb3Q1L1aH2LEcyEVFPPgXE888/j/Xr12PKlCnIyMjoGtFEg2M02yGXAXqNdAHxdVWjJK9NRMHLp4D48MMPsWrVKlx33XWBqiciGc12xGnVUEg0Yd6wIVq8v+uYJK9NRMHLpz4Il8uF/Pz8QNUSsbwjmKS77eewNB2MFjvaeH9qIurGp4CYPXs2/vnPfwaqlohlMNsluUiuU2qiBsooOerOsqOaiH7gUxOTTqfDa6+9hkOHDmHMmDFQKpU91i9evNivxUUKg0maayA6KeQyZKRoUdto5v2piaiLTwGxZcsWaDQaVFVV9bo3hEwmY0AMkMFsR0aKVtIahqfqUNvIkUxE9APekzoIGM12FEj8zT0zVYcjJ1okrYGIgsuAbxhkMBggCJy/xx+k7qQGeAZBRL35FBButxt/+ctfcMUVV2Dq1Kmoq6sDAKxatQpvv/12QAoMd4IgSN5JDQDD03RoabPBYnVKWgcRBQ+fAuJvf/sbtmzZgieffLJHB3V+fj42b97s9+IigdXugt3hlrSTGgCGJntHMp06Y5K0DiIKHj4FxObNm/Hb3/4WN998M+TyH56ak5ODkydP+vTCDz30EHJzc7F///6uZXv37sXs2bNRWFiIWbNmYfv27T7tMxQZz02zIXUTk0Ihx7BUHU4yIIjoHJ8C4syZM8jOzu61XKFQwGaz9Xs/W7Zs6bV9XV0dlixZgoULF6K8vBzLli3D8uXLcfjwYV9KDDkGsx2qKDlio30aLxAQI9L1DAgi6uJTQGRkZPQa3gp4v/mPGjWqX/toaGjA6tWr8bvf/a7H8s2bNyMnJwfz5s2DSqVCSUkJSkpKwr5vw2C2IV6nDop5rUak69nERERdfPraescdd+DZZ5+FWu1tLz958iS++OIL/PnPf8ayZcsu+nxBEPDEE09gyZIlGDp0aI91VVVVKCgo6LGsoKAA27Zt67WfsrIyrFmzxpfSg5ZU94HoS1a6Hv+zoxqCIARFYBGRtHwKiIULF8JoNGLp0qWw2WxYtGgR1Go1HnzwQdx6660Xff6GDRsgCAJuu+22XussFkvXHeo66fV6WCy9p38oLS1FaWlpj2W5ubm+vJWg0XkGEQxGpOthtbtw1mBFamKs1OUQkcR8bvguLS3FrbfeiubmZgiCgNGjRyM29uIfJjU1NVi7di3eeeedPtdrtVqYzT3H4ZtMJmi10l5hHGhGsx0J+uA4g0jQqaHXqHDydBsDgoj6HxCtra1YtWoVPvnkk65v9TqdDjNnzsSvfvUrJCYmXvD5X331FYxGI+bMmdNj+S9+8QvceOONyMvLw+7du3usq6ysRF5eXn9LDEkGsx2XDIuXugwA3ulSOjuqJxWkS10OEUmsXwFhtVpxxx13wGAw4KabbsLo0aMhCAK+++47fPjhhzh48CD+8Y9/IDr6/N+Er7/+ehQXF/dYdtVVV+H3v/89iouLYTKZ8Nprr2HTpk2YPXs29u7di507d+LNN98c3DsMct6rqIOjiQkARmXE4Vh9m9RlEFEQ6FdArF+/Hna7HR988AFSU1N7rHvwwQexYMECbNiwAffdd9959xETE4OYmJheyxMTExEXF4e4uDisXbsWK1euxIoVK5CWlobnnnsOhYWFPr6l0GIw2REfJJ3UAJCdGY+9/zkjdRlEFAT6FRCfffYZHnzwwV7hAACpqalYtGgRtm3bdsGA6Et1dXWPv4uLi7F161af9hHKPB4BRosdCRJPs9FddkYczrZ2wNzhgC5WJXU5RCShfl0Hcfz4cYwfP/686ydMmIBjx3jLSl+ZOxzweISgGeYKAENTtIhWKXCszih1KUQksX4FhMViQXx8/HnXx8fH9zkclS7McG6ajWAZ5gp4bx40cmgcjtWxH4Io0vUrINxuNxQKxfl3IpfD7Xb7rahIYTDZoImOglp5/mMrhdHD4tlRTUT964MQBAGPPPJIr1uMdnI6OUX0QBjMwdVB3Sk7Iw7v/u+3UpdBRBLrV0DccsstF90mMzNz0MVEmlaTLag6qDuNzozH6eZ2WKxOaGP6/lJAROGvXwGxcuXKQNcRkVpNNiTpew/9lVpmqg4xagW+qzFgXO4QqcshIokM+JajNHgtbVYkxQVfE5NCLsMlwxJQXWOQuhQikhADQkKtbTYkBmFAAEBuVgKqTzEgiCIZA0JCLSZbUJ5BAEBeViKqT7VCEASpSyEiiTAgJOLxCDAEaR8EAOQMT4C5w4kzze1Sl0JEEmFASMTU7oDLLQRtE1O8To3UxFhUsZmJKGIxICTS0mYFACQG4TDXTnlZiag62Sp1GUQkEQaERFpNNug1Kiijgusq6u7GZieh4niz1GUQkUQYEBJpaQveDupOBaOSUNtogfHcnFFEFFkYEBJpNdmQGCS3Gj2fzCFaxOvUqDzeInUpRCQBBoREvGcQwTmCqZNMJsPYUUmoOMZmJqJIxICQSLBeRf1jl45KQgXPIIgiEgNCIqHQxAQABdnJOHnGhDYL+yGIIg0DQiItQTzNRnfD03RI0Klx+LsmqUshIpExICRgd7phancgJT64+yAAbz/EuNwhOFh9VupSiEhkDAgJtBi9F8mFQkAAQFHuEByqbuK8TEQRhgEhgSajFdEqBTQhcjOey3NSYDDbcKrBLHUpRCQiBoQEmgxWpCTEQCaTSV1Kv8Rp1cjOjMfBKjYzEUUSBoQEmoxWpMTHSl2GTybkpaL8aIPUZRCRiBgQEmg2WpEcIv0PnSYXpOHI8RYOdyWKIAwICTQZOpCSEFoBMSojDsnxMThQybMIokjBgJBAc5sVyUE+zcaPyWQyTC5Ix5cVDAiiSMGAEJkgCF2d1KFmckE6Dn17Fla7S+pSiEgEDAiRtVudsDncIRkQ+SMToYlRYn/FGalLISIRMCBE1nTuIrlQa2ICAIVCjunjMrDzYJ3UpRCRCBgQImsyWBGvVUOlDN47yV3IjKJM/Lv6LAxmm9SlEFGAMSBE1mS0Ijk++CfpO5/RmfFIT9Zi96F6qUshogBjQIjsbGsHUhJC6yK57mQyGUomZOKTAzWcm4kozDEgRNbQ2o70JI3UZQzKtROzUNtoRnWNQepSiCiAGBAia2jpQFpS6J5BAECiPhqTC9Lx0d6TUpdCRAHEgBCRIAhoaGlHaoifQQDA9VNGYPe/62Fqd0hdChEFiGgB8eKLL+KGG25AUVERpk2bhieeeAIGQ88miiNHjmDBggUoLCzEjBkzsG7dOrHKE4XF6kSHzRXyZxAAcOnoZKQlxeKjfSekLoWIAkS0gFAoFHjxxRexf/9+vP/++2hoaMDy5cu71lssFjzwwAOYNm0aDhw4gNWrV2PNmjX4+OOPxSox4Bpa2iGXIeRmcu2LXC7DLVeNxoe7T8DhdEtdDhEFgGgB8atf/Qr5+flQKpVISkrCwoULceDAga71O3bsgFwuxy9+8Quo1WpcfvnlmDdvHjZs2CBWiQHX2NqB5PgYKKPCo2VvxvhMyOXAZ1/VSl0KEQWAZJ9U+/btQ15eXtffVVVVyM/Ph1z+Q0kFBQWoqqrq9dyysjLk5ub2eIQCbwd16Pc/dFJGKXDT9Gy899l3cLo8UpdDRH4mSUBs374dGzduxJNPPtm1zGKxQKfT9dhOr9fDYrH0en5paSmqq6t7PEJBQ0s7UhNDv3mpu/8qHgm7043/PXBK6lKIyM9ED4ht27bh6aefxtq1azF27Niu5VqttlcYmEwmaLVasUsMmMaWDqSGQQd1d9HqKMz/SQ7e/uRb2NkXQRRWRA2IjRs3YsWKFfjrX/+KyZMn91iXl5eHI0eOwOP5oamisrKyRzNUqGtobUdaYvg0MXW6bkoWohQybNn1vdSlEJEfiRYQ69atw6pVq/D6669j/PjxvdbPnDkTbrcba9euhcPhwDfffIONGzfi9ttvF6vEgHK5PThrsIbFENcfU0YpcN/sAmz89Ds0n5utlohCn2gB8eyzz8JiseCuu+7CuHHjuh6nT58G4G1ieu211/DFF19gwoQJKC0txUMPPYTrr79erBIDqqGlHR6PgIyU8Gky66740nTkDk/A6x9USF0KEflJlFgv1J+O5Pz8fLzzzjsiVCO+2kYL4nVqaGNVUpcSEDKZDA/ecike+dMuHKhswMSxaVKXRESDFB4D8kNA3Vkzhg3RXXzDEDY8TY8F1+bgpfcOw2J1Sl0OEQ0SA0IkdWctyBwSns1L3c29+hLE69R4+b3DnA6cKMQxIERSHyEBEaWQ4/E7x6P8SAM+OVAjdTlENAgMCBEIgoC6s2ZkhnkTU6fMITosmXsZXvnHN/i+1ih1OUQ0QAwIERjNdrTbXBFxBtHp6gnDMXNSFp59Yz/vX00UohgQIqg9a4ZKqUByfIzUpYjq/psKMDRFixWvfYkOGzutiUINA0IEdWctyEzRQi6XSV2KqKIUcjxxz0R4PAKe+/sB2BwuqUsiIh8wIERQ22BGZmrkNC91p4lR4reLpqDVZMNv/8YzCaJQwoAQwbH6NowaGid1GZJJ1Edj5S+mweZw4cm/7uVtSolCBAMiwDweASfPtGFURuQGBADEadV4dvFUKBVyLHtpN0439Z7GnYiCCwMiwM60tMNqd0d8QADe5qZnfj4FI9Lj8MvVu7D3m9NSl0REF8CACLDj9W1IjotGnFYtdSlBIVodhcfvHI87rxuDF9/6Cq9/UMF7WhMFKdEm64tUx+vbMCojXuoygopMJsNPrxyF0ZnxWLX+K5QfacTSeYUoyE6WujQi6oZnEAHmDQg2L/VlzMhErHn8alyRn4on/7oXZe/+GwYTL6ojChYMiAASBOFcQOilLiVoxaijcP/sAqx6+EqcPNOGRSv/F+u2H4GlgyOdiKTGJqYAammzwWixI5tNTBd1ybAErHp4Or6saMBbHx/F9j0ncO2kLFw/ZQSGhulNloiCHQMigCqPtyA5LhopCZE1xcZAyWQyTLk0HRPHpmHff05j+56TWPz8p7j8khRMH5eBK/LT2NlPJCIGRABVnmhB/qgkyGSRNcXGYCnkMkwrzMC0wgycajBhx5ensGFHNcre/TfyRyWhKHcICi9JQXZmPBQRNn0JkZgYEAF05HgL/mvqSKnLCGlZaXosuvlSPHBTAY7Xt2F/ZQPKjzTirY+rEKOOwmWjk1E4OhmFOSnISNEyjIn8iAERIOYOB041mDF2ZJLUpYQFmUyG7Mx4ZGfG445ZeeiwOVFxvAWHv23CR/tO4q+b/4PkuGhcdkkKLs9JwRVjUsP2/t9EYmFABMjRE63QxigxLDUybhIktthoJSbmp2FifhoAwGCy4fD3zTj8bRPWbTuCl947jBlFmbhh6kiMjOB5sIgGgwERIBXHWzBmZGLETfEtlQR9NGYUZWJGUSY8HgGHvj2LD/91Ao/86XMU5Q7B3TfkMyiIfMSACJCvjjbgv4rZ/yAFuVyG8XmpGJ+XitNNFrz1cRUe/dPnmDF+GO68bgxHlRH1Ey+UC4DTTRbUNlq6mj9IOkNTtPg/Cydg1SPT0WSw4qEXP8XW3cfh9ghSl0YU9BgQAXDgSANGDtVjSGKs1KXQOZcMS8CzS4qxeE4h/mdHNX5Tthsnz5ikLosoqDEgAmB/ZQMmjU2Xugz6EZlMhqsnDMPa31yN9BQNfvnnz/H/PjrK2WSJzoMB4WdtFjuOHG/BpLFsXgpWcVo1HrtjPP77vsn4/GAdHv7j56g83iJ1WURBhwHhZ599VYv0ZA2yMzliJtgV5Q3BS78uwYQxqXhi7R6s3XSY98wm6oYB4UeCIODjfSdx3ZQRvKI3RESro/DATQV4Yek0VB5vwUMvfIYDlQ0QBHZiEzEg/Oib75vRZLTi6gnDpS6FfJSblYg//3IGZk4egefXlePpV/fhVAM7sSmyMSD8aOvu45haOBR6Dad4CEXKKDlun5mLtb/5CTQxSjz8x8+xZuO/0dDSLnVpRJJgQPjJkRMtKD/aiPk/yZG6FBqkIYmx+M1dV+C5JVNxprkdD/7hU/xx/dc4cbpN6tKIRMUrqf1AEAS8sbUS104czrmXwsjYUUl4dslUVJ1qxXuffoeH//g5Rg7VY0ZRJqZdnoEhCbzOhcIbA8IPPt53EqcaTFh+z0SpS6EAyMtKxFP3TUKTwYovDtVh59d1eOPDI0hP1qBgVBLyRyZheJoOmUO0iI1WSl2uZARBgMvtgc3hht3hht3phiAIkMtkkMlkkMm806CoohRQKeVQRikQpZAFbECH2yPA6XLD4xGgUioQpWCDia8YEIP0fa0Rr26pwKMLxiFRHy11ORRAKQkxmHv1JZh79SU409yOimPNqDjego2ffouG1g54PALidWok6qIRp1UhTqdGnEYNTYwS6nMfiCqlAmqlvOsDyyMIEAQBggDvAwI8nnMPwfvT7QE8Ho/3d0GAx4Ou9Z2jrboPuhLQ44++fu2xffc/+losQIDL5UGHzQWr3fXDT7sTVpsLHXaXNxAcLvg6g4lMBu9xiZJ3hUbXzyjvcVJG/XC8XG4PnC4PnC43HE7vT6fLA4fLA6fT7f15bpnL3bMYhVyGaJUCapUCmhgl9Bo19BpVt4ca8To1UuJjkJIQgyR9NBQRHioMiEE4cboNz7z+JWZOGo6rijKlLodElJ6sQXqyBtdOygIAOF1unGlux5nmdhgtdhgtdrRZHGg12VB31gyH0wOH0w2Hy33upwdutweADHIZAFnPn3KZDHK5DAq592fX77If/u78vVP37+E9vpX3/et5v7n3fKr3D2WUHLHRUdBrVEhNikWsOgox0UrEqKMQq46CWqU49+Eb5f2p9H4Qy2QyCEJn4AFuT+cHvPd4dP50uDxwuTznjk/PAHB02zZKIYcqSg6l0hsgyqgfhYrSu0wV9UOwyOUyOJzesxqbwwWbw40OmxOmdgfaLA6Y2h2obTTD1N6CVpMNzUYbXG4P5DIgUR+N5PgYpCZqkJmqReYQLTKH6DA0WQOVUjGg/51QEnQB4fF4sHr1arz33nuwWq0oKirCM888g4yMDKlL6yIIAvZ8cxprNh7GlZdn4Oe3XCZ1SSQxZZQCw9P0GJ6ml7oUGiSPR0CbxY4mo9X7MFjR2NKOyuMt+OeXp9BstEImA1ITY5E5RIfhqToMT9NhWKr392h10H2sDljQvZPXXnsNH374Id566y2kpqbiD3/4AxYvXoz3338fcrm0p3sutweHqs/i/S+O4ehJAxZen4ebpmfzojiiMCKXy5Cgj0aCPho5wxN6rbfaXahvsqDurAW1jWbUNpqxv/IMzjS3wyN4R8ENT9Uh61xoDEvVITUxFnqNKuQ+K4IuIN5++2088MADGDVqFADg8ccfR3FxMb7++mtcccUVAXlNS4cDpg4HXOfaLV1uD6x2F0wWB9ra7WgyWHGywYSjJ1ohCAJKxg/D0nmXIy1JE5B6iCh4xaijMDozHqMz43ssdzjdqG+yoKbBjJpGM2oaTPiy4ofgUCkVXf0bifpo6GJV0MUqoY1VQRujhFql6Goa6/7obE6EzNvkJ5Ohq9NfBhnkciBBFx2Qm5MFVUCYzWbU19ejoKCga5ler0dWVhaOHj0asID41eovcKbbxVAyGaBWKhCnVSNeq0ZiXDRGZ8Zj9pWjMHZkUlidQhKRf6iUCowcGtfrzoVOlwctbZ3NVR1oMljRarLBYLahttEMc4cDlg4n7E53Vwe70+Xx6Z4lS+ZeFpAblAXVJ53FYgHgDYXudDpd1zoAKCsrw5o1a3o9Pzc3N7AFEhEFoV9+CPwyAPsNqoDQarUAvGcS3ZnN5q51AFBaWorS0lJRaxNLbm4uqqurpS4j5PC4DQyP28BEynELqkG+Op0OGRkZqKio6FpmNptRU1ODMWPGSFgZEVHkCaqAAIAFCxbg9ddfx4kTJ9DR0YEXX3wRI0aMwPjx46UujYgoogRVExMAPPDAAzCbzbjjjjtgtVoxfvx4rF27VvIhrkREkSboAkIul+Oxxx7DY489JnUpkli6dKnUJYQkHreB4XEbmEg5bjKBt84iIqI+sN2GiIj6xIAgIqI+MSACzOPx4E9/+hOKi4sxbtw43H///aivrz/v9keOHMGCBQtQWFiIGTNmYN26dX1u53K5MHfuXOTm5qKuri5Q5UsiEMdsx44duOWWWzBu3DhMnjwZK1asCORbkIS/j9vJkyfx4IMPYtKkSZg4cSLuvffesBz778txs9lsePjhhzFz5kzk5eWhrKxsUPsLegIF1CuvvCKUlJQIx44dEywWi/DUU08JN954o+B2u3ttazabhSlTpghlZWWCzWYTDh06JFxxxRXCRx991GvbsrIy4b777hNycnKE2tpaMd6KaPx9zD744ANh8uTJwueffy44HA7BarUKFRUVYr4lUfj7uN1yyy3Co48+KpjNZsFutwvPPvuscNVVVwkej0fMtxVwvhw3m80mvPHGG8K+ffuEefPmCX/5y18Gtb9gx4AIsJKSEmH9+vVdf7e1tQljx44VDhw40GvbTZs2CVOnTu3xj/TCCy8ICxcu7LFdRUWFcM011whHjx4Ny4Dw5zFzu93ClVdeKbz11luBL1xi/v5fKyoqEnbu3Nn1d3V1tZCTkyO0trYG5g1IxJfj1t2dd97ZZ0AMdH/BiE1MAXSxyQd/rKqqCvn5+T2u+SgoKEBVVVXX3w6HA8uWLcPTTz/dY/qRcOHvY3bixAk0NjbCYDDghhtuwOTJk3H33XfjyJEjgX8zIgrE/9rixYuxZcsWmEwmWK1WvPPOO5g4cSISEnpPgR2qfD1uYu9PagyIAOrv5IPdt9fpdD2W6fX6HtuuXr0al112GaZNmxaAiqXn72NmMBgAAB999BFefvll7Nq1C0VFRVi0aBFMJlMg3oIkAvG/duWVV6K+vh4TJ05EUVERdu3ahWeeeSYA1UvH1+Mm9v6kxoAIoP5OPth9+x//E5lMpq5tDx48iI8//hjLly8PUMXS8/cx6/x59913IysrC2q1GqWlpejo6MChQ4cC8RYk4e/jZjKZcNddd2HatGk4ePAgDh8+jAceeAC33347mpqaAvQuxOfrcRN7f1JjQASQr5MP5uXl4ciRI/B4PF3LKisrkZeXBwDYs2cPmpub8ZOf/ASTJk3CnDlzAABz5szBK6+8EuB3Iw5/H7ORI0ciJiamx528vDdbCa07e12Mv49bTU0N2tracP/99yM2NhYqlQoLFiyAx+PBwYMHA/+GROLvCULDbcJRBkSA+TL54MyZM+F2u7F27Vo4HA5888032LhxI26//XYAwL333osdO3bg/fffx/vvv49XX30VAPDqq6/iZz/7majvK5D8eczUajVuvfVWvPnmm6irq4PT6cRLL72E2NhYFBUVif3WAsqfx23UqFFISEjA3//+d9jtdrhcLrz77rtob28Pu/uu+DpBqMPhgN1uh8fjgcvlgt1uh8PhGPD+gprUveThzu12C6tWrRImT54sFBYWCvfdd1/XqKPy8nLh8ssvF+rr67u2r6ysFObPny9ceumlwvTp04U333zzvPuura0Ny1FM/j5mdrtd+N3vfidMnDhRmDBhgnD33XcLR48eFfU9icHfx+3w4cPC3XffLUycOFEYP368MGfOHOGTTz4R9T2JwdfjVlJSIuTk5PR43Hnnnf3aX6jhXExERNQnNjEREVGfGBBERNQnBgQREfWJAUFERH1iQBARUZ8YEERE1CcGBBER9YkBQUREfWJAEBFRn/4/EaHsquVfEQoAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cors_cor = list(map(lambda x: x[0], cors))\n",
+    "sns.kdeplot(np.array(list(cors_cor)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.04454298012082488"
+      ]
+     },
+     "execution_count": 70,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.median(np.array(list(cors_cor)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Across pseudo-bulk cell aggregates by cross magic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cors = Parallel(n_jobs=-1)(\n",
+    "    delayed(pearsonr)(\n",
+    "        adata.layers['X_magic'].toarray()[:, i],\n",
+    "        adata.layers['gene_score_cross_magic'].toarray()[:, i],\n",
+    "    )\n",
+    "    for i in range(adata.layers['X_magic'].shape[1])\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<AxesSubplot:ylabel='Density'>"
+      ]
+     },
+     "execution_count": 72,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAD9CAYAAAB9YErCAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA00UlEQVR4nO3deVhTZ94//ncS9iyyB8IqKJsghE1Bi8u0irZOdWo71ta249I6v5ZOZ6zdpp1nxvlOR4u1rfYps+A405GO1dal6ji2dV+KIKIIAqKAQNiRJRBCSHJ+f/DAiGwJkpwsn9d1cRWTk3M+p5C8Ofd9n/vmMAzDgBBCCBkHLtsFEEIIMV8UIoQQQsaNQoQQQsi4UYgQQggZNwoRQggh40YhQgghZNxs2C7AkEJDQ9kugRBCzE5paanO21p0iAD6/c8ghBBrp+8f39ScRQghZNwoRAghhIwbhQghhJBxoxAhhBAybhQihBBCxo1ChBBCyLhRiBBCCBk3ChFCiEXTahnUt3RBq6WlkwzB4m82JIRYr+PZldh7ogyNdxVwFdnjqR+F4NHZQWyXZVEoRAghFmn/qVvY/Z9ivPBYBBIjvHD1ZhP+cvA61FoGj6cEs12exaAQIYRYnAsFtfjnsWK8uzoRcWFiAEBqEh9ukxzwh105mOLrjGlBbixXaRmoT4QQYlE6FSr8eX8Bnk0NGwiQfgkRXlgwMwCZ3xRSH8kEoRAhhFiUvx+9AReRA5bOGb7J6pmFYahr6sTpKzVGrswyUYgQQixGXXMXvsupwvpl08HjDf/xNklgj2XzpuDA6VtgGLoaeVAUIoQQi7HvxE1MD3ZH+GTXUbdbkBiA6gY5bla1Gqkyy0UhQgixCI13FTh5uRorFoy9HoaLyAGJ07xwPPuOESqzbBQihBCL8O+LFQjxd9F51NWCGQE4e1UGhbLXwJVZNgoRQojZ61Vr8F1OFRYnB+r8GmmoJxztbJBX3Gi4wqwAhQghxOxduFYLAJgVLdH5NTwuBwkRYlwqqjdUWVaBQoQQYvb+k30HjyT6w9aGp9frEqd54XJJA9QarYEqs3wUIoQQs1bf0oWi8hY8nOiv92tjpnqgt1eDGxUtBqjMOlCIEELM2ukrNZjq5wxfT6Her3Wwt0FMiCcuFVKT1nhRiBBCzBbDMDh1uRrz4vzGvY/YME9cLWuawKqsC4UIIcRslVW3of6uAg/F+Ix7H1HBbqiql6NN3jOBlVkPChFCiNk6my9DTIgHnIX2496Hn1iISQI7FJVTv8h4UIgQQsySVsvgQkEtZk/XfVjvcDgcDiKD3XH9dvMEVWZdKEQIIWaprLoVrR1KzIzyfuB9RVGIjBuFCCHELJ2/VovoqR4QOtk98L6oX2T8KEQIIWaHYRhcvF6n1x3qo/ETCyF0skPJnbsTsj9rQiFCCDE7lXUdaGpVIDHCa0L2x+FwEOLvTFPDjwOFCCHE7OQU1SMswPWBRmXdL9TfhUJkHChECCFm51JRPRKnTcxVSL+p/i4oq26jtdf1RCFCCDErLe3dKKtuw4wJDpEQfxcolGrImjondL+WjkKEEGJWcm80wNudD19PwYTuV8S3g7c7n5q09EQhQggxK5eK6jFjmhc4HM6E7zvEzwWlFCJ6MWqIaLVabNu2DcnJyZBKpVizZg1kMtmI23/zzTdYsmQJYmNjkZKSgj/84Q9QqVRGrJgQYkqUPWpcK2ua8P6QfiH+ziirbjPIvi2VUUMkMzMTR44cwe7du3H+/HlIJBKsX78eWu3QBWFKSkrw5ptv4uWXX0ZeXh7+9a9/4fz58/jss8+MWTIhxITk32yCvS0PEYGuBtl/kM8kVNV1QEOLVOnMqCGyZ88erF27FkFBQeDz+di4cSMqKiqQl5c3ZNvq6mpMmjQJqamp4HA48PHxwdy5c1FSUmLMkgkhJiSnqB7xEWLweIb56JosmQSVWosa6lzXmdFCRC6XQyaTITIycuAxkUiEgIAAFBcXD9l+9uzZ8PX1xdGjR6HRaFBVVYWTJ0/ikUceMVbJhBATotEyyC2un/BRWffiO9pC7OqEClm7wY5haYwWIp2dfckuEokGPS4UCgeeu5ejoyOWL1+O//mf/0FUVBQeeeQRSKVSLF26dNj979ixA6GhoYO+CCGW4+adVnR19yI21NOgxwnymYTy2g6DHsOSGC1EBIK+4XhyuXzQ43K5fOC5ex04cADbtm3Dn/70JxQWFuLcuXNobW3Fm2++Oez+09LSUFpaOuiLEGI5LhXVISrYHU4OtgY9TpDPJLoS0YPRQkQoFMLHxweFhYUDj8nlclRVVSE8PHzI9oWFhZgxYwbi4+PB5XLh6emJp556CidOnDBWyYQQE9I/tNfQgiSTUF7bDoahO9d1YdSO9RUrVmDnzp2oqKiAQqFAeno6AgMDERcXN2TbuLg45OTkID8/HwzDoKWlBXv37h3Up0IIsQ6ypk7UNHYiwQghMlkyCR1dKtztUBr8WJbAxpgHW7t2LeRyOVauXInu7m7ExcUhIyMDXC4Xly9fxrp163D06FFIJBIsXrwYTU1NePvtt9HQ0ABHR0ckJibit7/9rTFLJoSYgJyiekyWiODp4mTwY7k7O0DoZItyWTvcJjka/HjmjsNY8DVbaGgo9Y0QYgHe/uw8IoPc8UxqmFGO99b/nkdCuBhPzJ9qlOOZEn0/N2naE0KISZMrVLhRcReJ08RGO2aAlxB36mmEli4oRAghJi2vuAHOAnsE+zgb7Zj+XiLcqZePvSGhECGEmLZLRfVIiBCDy534CRdHEuAlRE2DHBpaW2RMFCKEEJPVq9Yir6TRKEN77+XvJYJKrUVDS5dRj2uOKEQIISarqLwZWobB9KkeRj2uiG8HF6E99YvogEKEEGKyLhXVI2aqB+xteUY/dgD1i+iEQoQQYpIYhkHOjQajN2X18/cW4k4dXYmMhUKEEGKS7tTL0dSqQHyE8Yb23stfLEJVA12JjIVChBBiknKK6hHi7wIXoQMrx/f1FKCuuYtGaI2BQoQQYpJyiuqRGMFOUxbQFyK9ai2aWhWs1WAOKEQIISantUOJm9WtrPWHAH0jtIROtqhppFUOR0MhQggxObnFDfBwcYK/l5C1GjgcDnw8BBQiY6AQIYSYnJz/WzuEwzHeXerD8fUUoqaROtdHQyFCCDEpPb0a5N9sQiJLo7Lu5eMpgKyJrkRGQyFCCDEpV0oaYGfDRWSwO9ulwNeTmrPGQiFCCDEpFwvqkDjNCzY89j+efDwEaJP3oLO7l+1STBb7PyVCCPk/vWoNcm7UY1a0hO1SAADe7nzwuBzIqF9kRBQihBCTcfVmExgGkIYYd8LFkdjwuPByc6J+kVFQiBBCTMbFgjokRIhha2P8CRdH0jdCi0JkJBQihBCToNZocamoDsnTTaMpqx/dKzI6ChFCiEkovN2Mnl4t4kI92S5lEBqhNToKEUKISbhQUIf4cE842NuwXcogPv0TMWq0bJdikihECCGs02gZZF+vQ3KUaTVlAX19ImqNFg00EeOwKEQIIawrvN0MhbIXCSZwl/r9+iZitIOMmrSGRSFCCGHdmSs1SJjmBScHW7ZLGRb1i4yMQoQQwipVrwYXCmoxN9aX7VJG5EtzaI2IQoQQwqrLxQ3gcjiICzO9pqx+dCUyMgoRQgirTl+pwaxoCWxtTPfjSOIhoD6REZjuT40QYvE6u3uRe6PBpJuyAEDizkdbZw8USpqI8X4UIoQQ1lwsqIWz0B4Rk93YLmVUXm58cDhAbVMX26WYHAoRQghrzlypwRypD7hcdlcwHIudLQ8eLk6obaYmrftRiBBCWNHc1o3rt5sxx8SbsvpJ3PmobaYrkftRiBBCWHEitwqTJZMwWTKJ7VJ0InHno5aG+Q5BIUIIMTqtlsG3OVVYODOA7VJ0JvEQ0JXIMIwaIlqtFtu2bUNycjKkUinWrFkDmUw24vZKpRKbN29GSkoKYmJi8Mgjj+DMmTNGrJgQYgjXyprQJu9BitQ8mrKA/isRCpH7GXW6zMzMTBw5cgS7d++GWCzG5s2bsX79ehw6dAhc7uA8YxgGL7/8MgAgKysLfn5+qK+vh1qtNmbJhBADOH7pDmZHSyBwNM1pToYj8RBArlBBrlBB6GTHdjkmw6hXInv27MHatWsRFBQEPp+PjRs3oqKiAnl5eUO2vXDhAnJzc5Geng4/Pz8AgJeXF3x9zecvF0LIUO2dPbhUWIcFM8ynKQsAxK5O4HI51C9yH71CZLgPe13J5XLIZDJERkYOPCYSiRAQEIDi4uIh22dnZ8PX1xcZGRmYNWsW5s+fj9///vfo6qLLSULM2cnL1fBy4yNisivbpejFhseF2MWJ+kXuo1eIPPvss3jsscfw+eefo729Xa8DdXb2pbdIJBr0uFAoHHjuXq2trbh9+zYA4Pvvv8fu3buRn5+PLVu2DLv/HTt2IDQ0dNAXIcS0MAyDby/dwYIZAeBwTPvekOF4e1C/yP30CpHvvvsODz/8MHbu3ImUlBS8/vrryM3N1em1AoEAQN8Vyb3kcvnAc/fi8/ng8Xh4/fXX4ejoCIlEgnXr1uH7778fdv9paWkoLS0d9EUIMS1F5S2ob+nCvDg/tksZl757Rag56156hYivry9ee+01nDp1Ch9//DEUCgV+9rOfITU1Fbt27cLdu3dHfK1QKISPjw8KCwsHHpPL5aiqqkJ4ePiQ7SMiIgBg0F8r5viXCyHkv745V47ZMT5wFtqzXcq4SNxpmO/9xtWxzuVyMW/ePOzYsQNvv/02ZDIZtmzZgrlz5+Ldd99Fa2vrsK9bsWIFdu7ciYqKCigUCqSnpyMwMBBxcXFDtn3kkUfg5uaGjz76CCqVCg0NDcjMzMTChQvHUzIhhGUNdxW4VFiHHz8UxHYp4ybx4KOuqRMMw7BdiskYV4hUVVXhww8/xJw5c/Dxxx/jySefxMGDB7Fjxw6UlpYODM2939q1a7Fo0SKsXLkSycnJkMlkyMjIAJfLxeXLlyGVSlFbWwugrznrb3/7GwoLCzFjxgw8+eSTiI2NxRtvvDH+syWEsObohQqEBrhiqp8L26WMm4+HAF1KNTq6VGyXYjI4jB6RevToUezduxc5OTmYNm0aVqxYgUcffRSOjo4D29TU1GDhwoUoKioySMH6CA0Npb4RQkyAskeNF37/LV55Mhqzo33YLmfcNBotlr99BO//fDbCzWx0ma70/dzU62bD9957D4899hjefPPNgT6L+7m7u+PnP/+5PrslhFi4k3nVcLS3QVKkN9ulPBAejwuxa1/nuqWGiL70CpFz586Bz+ePuo2DgwNeeeWVByqKEGI5tFoGh8+V49FZk8Hjmf90fRIPms33Xnr9ROPj49HS0jLk8dbW1mFHWBFCyJXSRjS2dpvVZIujkbgL6K71e+gVIiN1n/T29oLH401IQYQQy8EwDPZ+fxMLZwZYzHxTErrhcBCdmrMOHjwIoO8+jWPHjg26OVCj0eDSpUsICLCMvzIIIROnsLwFZdWt2PhsPNulTJj+Gw4ZhqF716BjiPz6178e+P6Pf/zjoOdsbW3h6+uLt956a2IrI4SYvb3f38S8OD94uDiOvbGZkLgLoFRp0CrvgavIge1yWKdTiPQP150/fz6++uoruLrSqARCyOhuVrWioKwJGW/9iO1SJpS7syNsbbiobeqkEIGefSInT56kACGE6GTfiZuYHeMDifvQufHMGZfLgZcbjdDqN+aVyOHDh7Fw4ULY2dnh8OHDo267ZMmSCSuMEGK+7tR14FJRPbZvmMd2KQZB663/15ghsnHjRiQnJ8PNzQ0bN24ccTsOh0MhQggBAGQdL8HMSG8EeovG3tgM+dB66wPGDJGSkpJhvyeEkOHcrGrFpcI67HjdMq9CgL5hvldKG9kuwySY/+2jhBCT8s9/F2NunB/8vSzzKgT475TwWi3N5qtXiFy4cGHQErl79+7FE088gbfeemvY1QkJIdblWlkTCsub8fQCy15ZVOLBh6pXg7sdSrZLYZ1eIZKenj6wVkhFRQU2bdqEyMhIFBYW4oMPPjBIgYQQ88AwDP7572IsnBkIL7fR59gzd64iB9jb8WiVQ+gZIlVVVQgJCQHQt1RuUlISfve73+H3v/89Tp8+bYj6CCFmIruwHhV1HfjpwyFsl2JwHA4H3m58yGj6E/37RPpv88/NzcWsWbMAAGKxGG1tbRNaGCHEfPSqtdh1pAjL5gTDxUpuwOubQ4uuRPQKkdDQUHzxxRfIzc1FdnY2Zs+eDQCoq6ujmxAJsWJHL5SjR6XBE/Onsl2K0UjcBaijYb76hciGDRuwf/9+PPfcc1i6dCmmTJkCADh16hSioqIMUiAhxLS1d/Zgz7eleP7RcDja67VEkVnrn4jR2un1E4+Pj8fFixfR1dUFkei/w/eeeuqpQUvkEkKsR9bxEkg8BJgb68d2KUYl8RCgrlkBjZYBj2u9s/nq3SfC4/EGBQgA+Pv7w8PDY8KKIoSYhzt1HTiefQfrHo8C18o+SCXufKg1WjS3dbNdCqv0uhLRarU4cOAALl68iJaWFmi12kHPf/755xNaHCHEdGm1DDL2F2B2tMQq1xt3FtrD0Z6H2qZOiF2d2C6HNXqFyJYtW5CVlYWkpCT4+PjQgiyEWLETuVWoqG3HG6ssZ8EpfXA4HEj+bw4tqWXfWzkqvULkyJEj2Lp1K1JTUw1VDyHEDLR39mDXkSI8tzjCqtfU6Jv+xLo71/XqE1Gr1YiIiDBULYQQM/G3w0XwducjNSmQ7VJY1TclvHUP89UrRH784x/j+PHjhqqFEGIGrt9qxukrNXh5eYxVj0oC+m44rLPyKxG9mrOEQiEyMzORn5+P8PBw2NraDnp+/fr1E1ocIcS0dPeo8cmX+Xg8JRhBPpPYLod1EncB6lsU0Gi04PGsc1J0vULk4MGD4PP5KCkpGbK2CIfDoRAhxMLtOlwEO1sunk0NY7sUk+DtzodGy6ChVWFxywDrSq8QOXnypKHqIISYuCsljfj20h2kv/oQ7Gx5bJdjEkR8O/AdbVHb1GW1ITLu66/W1lYwDC3IQog16FSosH1vPp78UQim+rmwXY7J4HA4Vj/9iV4hotFosH37diQkJGDWrFmoqakBAGzduhV79uwxSIGEEHYxDIPPvi7AJIE9nrKCad71JXEXoM6KR2jpFSJ//etfcfDgQfz6178e1KkeERGBAwcOTHhxhBD2/ftiJS4X12Pjs3GwtbHOzuPRSDz4qLXi2Xz1+o04cOAAfvvb32Lp0qXgcv/70pCQEFRWVk50bYQQlpVVtyLzUCHSnpTC11PIdjkmiZqz9FBXV4fg4OAhj/N4PCiVtNYwIZakU6HC5s8vY+HMADwk9WG7HJMl8RCg8a4CvWrt2BtbIL1CxMfHZ8jQXgC4ePEigoKCJqwoQgi7NBottmblYRLfDmt+PI3tckyaxJ0PLQM03LXOJi29QmTlypX4wx/+gPPnzwMAKisrkZWVhY8++gjPPPPMmK/XarXYtm0bkpOTIZVKsWbNGshksjFfV1hYiGnTpmHVqlX6lEsIGQeG6Zudt7KuA++8kAhbGxrOOxqBkx1EfDur7RfR6z6RVatWoa2tDa+88gqUSiXWrVsHe3t7vPTSS1i+fPmYr8/MzMSRI0ewe/duiMVibN68GevXr8ehQ4cG9bHcq6enB2+//TYSEhKg0Wj0KZcQMg5fnSzD2XwZtrwyG+7OtNicLqx5Di2917JMS0vD8uXL0dzcDIZhMGXKFDg56TaX/p49e7B27dqBpq+NGzciOTkZeXl5SEhIGPY1H330EWbOnAmRSIScnBx9yyWE6OFUXjW+OF6C36yZickSmtZEVxIPAWqbrLNzXecQuXv3LrZu3YrvvvsOnZ19/7OEQiEWLFiAX/3qV3B1HX1RGrlcDplMhsjIyIHHRCIRAgICUFxcPGyI5Obm4tSpUzh48CAyMzN1LZUQMg7f51Th031X8epPYyAN9WS7HLMicefj+u1mtstghU4h0t3djZUrV6K1tRWPP/44pkyZAoZhUFZWhiNHjuDKlSvYv38/HBxGXlegP3juX1pXKBQOPHevrq4uvPPOO3j//fd1Wr99x44d+PTTT3U5HULIfY5eqEDmoet47elYzI31ZbscsyNxF+D4pTtsl8EKnUIkKysLPT09+OabbyAWiwc999JLL2HFihX44osvsHr16hH3IRD0zSsjl8sHPS6Xyweeu9eWLVswZ86cEZu57peWloa0tLRBj4WGWvFyY4TogGEYfHWyDF8cL8UbqxKQFOXNdklmyduDj+a2bqh6NVY3r5hOIXLy5Em89NJLQwIEAMRiMdatW4ejR4+OGiJCoRA+Pj4oLCxEVFQUgL4AqaqqQnh4+JDtz58/j46ODhw+fBgAoFQqoVarMWPGDHz11Vfw8/PT6QTJxFL1anCpqB7XyppQWduB9q4e8LhcOAvtMdlbhOlT3RET4glHe72724iRKVVq/O++a8i5UY/31sxALDVhjZvEnQ+GAepauhDgJRr7BRZEp3d6eXk54uLiRnw+Pj4e27dvH3M/K1aswM6dOzFz5kyIxWKkp6cjMDBw2H1/+eWXg0Zj7dq1C1evXsUnn3wCDw8PXcomE6hXrcWhs7dx4PQtcDhAbKgnUqQ+cBbaQ61hcLdDids1bdix9ypUai1SYnywdE4w/K3sDWUuyqpb8WHWFXA4wNZXU+AnprvRH4STgy2chfaobaIQGVZnZyecnZ1HfN7Z2XnYfo37rV27FnK5HCtXrkR3dzfi4uKQkZEBLpeLy5cvD1zRSCSSIUEhEAhgZ2cHLy8vXUomE+hOXQe2/DMXCqUaq5dMQ4rUZ8R7BzQaLa6WNeHohQqkbT2FuXF+eHpBKLzc+EaumgxHrlDhi+Ml+PfFSiycEYDVS6bBga4aJ4TE3TpXOeQwOsznHh4ejgsXLow4Aqu5uRkPPfQQiouLJ7zABxEaGorS0lK2yzBr2YV1+DArD7OjfbBuaSScHGzHftH/uVnVin/+uxiF5c14PCUYTy8Mg72VtRebiua2bhz7oRKHz5VD7OqE9T+ZjmlBbmyXZVE+2ZMPHo+DV56MYbuUB6Lv56ZOf4IwDINf/OIXQ5bD7dfb26vzAYn5OH9Nhg+z8vCzJdOwZHYQOBz91tMO8XfB79cnI7+0ERlfF+Di9TqkPRmDqCnuBqrYfDEMA5Vaix6VBlwOYGvLgy2PC+441zBnGAa1zV0ouNWM7Ot1uFrWhEBvEdKeisGs6ZJx75eMTOLBR35pE9tlGJ1OIbJs2bIxt/H1pWGBluRKSSM+zMrD+p9EY+HMgAfalzTUE9tfn4svjpfi3T9fxOKkQPxsyTSrG8UCAHc7lCipvIubVa2obe5Cw10FGu8qoFD2QjtMm4ANjwt7Wy4cHWzh5GADJ3sbODnYwvGe73lcDlRqDXrVWrR39qC+RYG6li70qDTw8RAgIUKMZ1LDMNXPWe8/BIjuJB4CHL1QwXYZRqdTiPzxj380dB3EhFTV9/WBPJMa/sAB0s/Bzgarl0zD7GgJtu7OQ2F5C95YFW/xHbpaLYObVa24UFCL7MI61Lco4CywR2iAC3w9BZCGeMDT1QkCR1s42NsMNPepejVQ9WqhUmvQo9Kgu0cNhVINRU8vupX936vRKldCo2FgZ8uFnS0PPh4CxId7QeLOh69YABfhyPdukYklceejpV2J7h61VY1OtJ4zJTpR9qjx/t9zMTPSG0/MmzLh+w/xd8HHv5qDz74qwC8/PoOXlkbh4UR/i/sLuVWuxPHsOzj+QyVa5T2IDvHA8vkhiJ7qDrGrk8WdLwF8PATgcoCaRrlVLSFMIUIGyfymEBwO8PMnphvsg87JwRYbnonFidxq/OlAAa7ebMLLT0br1Wlvqqob5AMTGPp6CvDTR0IxO1oCgZMd26URA7Oz5cHLjY/qBgoRYqVyb9TjRG41PvxFChzsDPurweFw8HCiP0IDXPDBPy/jtY/O4I1V8Zji62zQ4xpKXXMX9nxXitN51YgLF2PTS0mIDHKjKw4r4ycWoqpePvaGFoRChAAAunvU+OzrAjz1cAiCfIw3e6ufWIitv0hB5qFCbNx+Dmt+PA2PzppsNh++Xd29+Ne3pThyvhzTp7gj/dUUhPhbz1+hZDB/LyEq6zrYLsOoKEQIACDrPyVwtOdh+fyJ7wcZi70tDy8vj8b0YHfs2HcV1283I+0pKQSOptu8pdUyOHm5Cv84WgyRwA6/ezEJ0VNpJgVr5y8W4tzVsRfasyQUIgQ1jXIcOV+OTS8lsbqK3UNSHwT7Tepr3tp2Gm+sijfJv+pvVrXiLweuo6apE88sDMPi5EDweHotEkoslL+XCA13FVCq1AZvEjYV9JtP8LfDRUiIEGP6FPb/kpa4C5Ce9hASIsR489NzOHT2NnSYVMEo5AoV/vera9i44xwCvEX481s/wpKHgihAyAAfz74ZyWsarWf6E+uISjKia2VNyC9txP++MZ/tUgbY2vDw0rLpiAp2x/Yv83H1ZhNeeTIabpPYWaq1v+lq15Eb8HBxRHraQyZ5hUTYZ2/Lg5dr3wgtcx0koi8KESvGMAx2HyvGwpmBkLgPXdOFbcnTJQj2dcYne/LxcvopvLg0EvPi/Iza6V5R246MrwtQVd+BVYvCkZo8GTyaMoSMwt9LiOoG6xmhRSFixfJKGlEua8dbz+u28BcbxK5O+H/rk3Hsh0pkfF2As/kyrFsaBR8Pw4Zee2cPvvz+Jo5eqMAcqQ/efiGB7v4mOrG2Yb4UIlaKYRhkHS/B4lmTWWsm0hWXy8GjsyYjLswTmYcK8Ur6STw6KwgrFoRO+Aiu7h41vjl7G/tP34KXGx//b30yooJpwkiiO38vIS4U1LJdhtFQiFipglvNqKztwG9Wz2C7FJ15ufHx7uoZuHazCZnfFOJEbhUWJQdiyewguIge7CqhVa7EsYuV+PfFCjjZ2+Ll5dGYHe1Ds90SvfmJhWho6UJPr8Yqlj6gELFSX58sw48S/B74w5cN0SEe+PiXc3D+Wi32n76FA6dvY06sDx6K8cH0KR6wtdFttFRPrwbXyppw/qoM567Wwk8swAuPTsOcWF+d90HI/Xw9BWAAyBo7jXrjLlsoRKzQ7Zo2XCtrwmdv/ojtUsaNx+NiTqwvUqQ+KLjVjGM/VGLzP3LB5XIQG+qJ0ABX+IkFcHd2hKO9DRgGUCh70dzWjap6OUru3EX+zSbwuBzEh4ux6cUkRAbTNCXkwTnY2UDs6oSqBjmFCLFM+0/dwswob4N3ThsDh8NB9FQPRE/1gKpXg6tlTcgrbsC5qzWQNXWhq3vwgmkivh18PASY6u+Md15IRFSwO111kAnnJ7aeEVoUIlamvqUL56/JkP5qCtulTDg7Wx4SI7yQGOE18JhSpYayRwMOB4PW6yDEkPzFQlTVW8ccWhQiVubgmduYFuRuNTfLOdjZWM30E8R0+HsJkV1Yx3YZRkHX8Vakq7sXJ3KrsHRuMNulEGLR/MRC1DV3QdWrYbsUg6MQsSKnr9RAxLdDXJiY7VIIsWh+YiEYwCr6RShErATDMPjPD5VYODOQpu0gxMAc7Gwgceejotby+0UoRKxESWUrqhvkeCTRn+1SCLEKkyWTUFHXznYZBkchYiWO/VCBmVHeZnlzISHmaLJkEirpSoRYgo4uFc5fq8WipEC2SyHEakyWiFAuazeZ9XAMhULECpy8XAVPF0dMn0ITCRJiLJMlk9DZ3YvmNiXbpRgUhYiFYxgGxy5WIjUpkKb0IMSI3CY5QOhkZ/H9IhQiFq7gVjOa2roxP5461AkxJg6Hg8kSESpqKUSIGTv2QyVmR0sg4tuxXQohVifIZxLKZRQixEy1diiRfb0Oi5Ims10KIVYp2NcZt2ooRIiZ+i6nCn5iIcICrWOeLEJMzVQ/ZzTeVaC9s4ftUgyGQsRCabQMjl+6Qx3qhLDI240PJwcb3LbgqxEKEQuVX9qIjs4ezIvzZbsUQqwWl8tBsI8zbtW0sV2KwRg1RLRaLbZt24bk5GRIpVKsWbMGMpls2G2vXr2KF198EcnJyYiNjcWyZcvw7bffGrNcs/afHyoxJ9YXTg62bJdCiFWb4kchMmEyMzNx5MgR7N69G+fPn4dEIsH69euh1WqHbNve3o7FixfjyJEjuHz5MtavX48NGzagoKDAmCWbpabWbuTeqEfqzEC2SyHE6k3xnYSy6ja2yzAYo4bInj17sHbtWgQFBYHP52Pjxo2oqKhAXl7ekG3nzJmDpUuXwtXVFVwuFwsXLsTUqVOH3ZYM9u2lOwj2dcYUP2e2SyHE6k3xc0ZzWzfa5JbZuW60EJHL5ZDJZIiMjBx4TCQSISAgAMXFxWO+vqGhAeXl5QgLCzNkmWZPrdHi20uVNE8WISbC240PoZMtbla1sl2KQRht3dDOzk4AfcFxL6FQOPDcSLq6upCWloZ58+YhKSlp2G127NiBTz/9dGKKNWO5N+qhVGnwUIwP26UQQtB353pogCtK7txF4jQvtsuZcEYLEYFAAKDviuRecrl84LnhyOVyvPjii/Dw8MCWLVtG3C4tLQ1paWmDHgsNDX2Ais3TsYuVmB/nBwd7WlecEFMRFuCCq2VNbJdhEEZrzhIKhfDx8UFhYeHAY3K5HFVVVQgPDx/2Na2trXj++efh7e2NTz75BHZ2NHXHaOqau3C1rAmp1JRFiEkJC3BFWXUbNJqhg4jMnVE71lesWIGdO3eioqICCoUC6enpCAwMRFxc3JBtm5qasGrVKoSGhmLr1q2wsaG/rMdyPLsS4YGuCPAWjb0xIcRopvo7o7dXg4o6y1ukyqghsnbtWixatAgrV65EcnIyZDIZMjIywOVycfnyZUilUtTW1gIAvvzyS5SVleHYsWOIi4uDVCqFVCrFb37zG2OWbDZ61Rp8l1NFVyGEmCAnB1v4e4lQWnmX7VImHIex4GW3QkNDUVpaynYZRnE6rxp/PVSIXe8tgJ0tj+1yCCH3+eyra1Ao1Xj92aEtL6ZE389NmvbEQhy9UIEFMwIoQAgxURFBbigqb7a45XIpRCzA7Zo23KxqpaYsQkxYVLAbmtuVqG9RsF3KhKIQsQD/vliJ+HAviF2d2C6FEDICt0mOkLjzcf12M9ulTCgKETPX2d2L01dqsHhWINulEELGEDXFnUKEmJYTuVVwEzlAGuLJdimEkDFEBruj8JZl9YtQiJgxrZbBsYsVWJQcCC6XFp4ixNT194vUtXSxXcqEoRAxY1dKG9HcrsTDif5sl0II0YHbJEf4iQXIL7WcKVAoRMzYgdO38EiCP4RONB0MIeYiNlSMKyWNbJcxYShEzNStmjYU3m7Gj1OC2S6FEKKHuDBPFNxqQq9aw3YpE4JCxEwdPH0bM6O84e3OZ7sUQogepgW5QcsAN8otYwoUChEz1NiqwLlrMiybO4XtUggherKz5WH6FHfklVpGkxaFiBk6fK4cof4uCAtwZbsUQsg4xId5Iqeo3iKG+lKImJnO7l4cz75DVyGEmLGZUd6QNXWiukE+9sYmjkLEzBw8cwvuzo4WucwmIdbCbZIjwgJccPF6HdulPDAKETPS0aXCN2fL8czCMPDo5kJCzFpSlAQXC2rZLuOBUYiYkf2nyuDl5oSkKG+2SyGEPKDk6d6oqO1AbXMn26U8EAoRM9EqV+LIhQo8szCMpjghxAJ4ufER4u+MM1dkbJfyQChEzMRXJ8vgLxZSXwghFuRHCf44kVsFrdZ8R2lRiJiBptZuHLtYiWdTw8Hh0FUIIZYiJcYHLe1KFFW0sF3KuFGImIG/Hy1CeKArpKEebJdCCJlAAic7zIz0wvc5VWyXMm4UIiauqLwF56/VYu3jkXQVQogFWjAjAOevytDe2cN2KeNCIWLC1Bot/nLgOhbODMBkySS2yyGEGEBMiAfEbnwcz77DdinjQiFiwg6duY1WuRLPLQpnuxRCiIFwOBw8nhKEoxfK0avWsl2O3ihETFRtcye++LYULy2bDgGtF0KIRZsb54deNYMzV6rZLkVvFCImSK3RYlvWFcSHeyJ5Ot1YSIils7fl4Yl5U/Cv726a3dUIhYgJ+vK7m2hq68bLy2OoM50QK/Ho7Mno7dXg20vm1TdCIWJiLhc3YN+Jm/jV07EQ8akZixBr4WBng58+HII935Wis7uX7XJ0RiFiQmqbOrE1Kw/PLgpHdAjdE0KItUlNCoSL0B6fH73Bdik6oxAxEa1yJf7nrz8gLtQTT8yjtUIIsUY8HhcvL4/G8Ut3UFRuHnexU4iYgI4uFX77l2x4ujjhtael1A9CiBULDXDFjx8KwtasPHR0qdguZ0wUIixrlSvx64wLsLfj4dc/S4StDY/tkgghLHv+0Qi4T3LAh1/kQaMx7dFaFCIsulPXgdc/OQsR3w6/ezEJTg62bJdECDEBNjwu3liVgDt1Hdix76pJz/JLIcIChmHwfU4VXt9+FtFTPfDbdUlwtLdhuyxCiAnxcHHEpheTkFNUj0/3XYXaRK9IKESMrPGuAn/YlYM/HSjAuqVRSHsqBrY29GMghAzl7yXC+//fbOSXNmJTZjba5KY3SSN9ehlJa4cSO78pxM+3nECvWovtG+ZiwYwA6kQnhIwq0FuErb9IgVKlwStbT+LMlRowjOk0b3EYI1aj1Wrx8ccf46uvvkJ3dzdiY2OxadMm+Pj4DLv9jRs3sGnTJhQXF8PFxQWrV6/Gc889p/PxQkNDUVpaOlHl602pUiO/tAnnr8pw8XotAr1FeCY1HHFhnhQehBC9aLQMDp25hT3flcLHU4ifzJ2CpChv2PAm9lpA389No4bIX/7yF+zZsweZmZkQi8XYvHkzrl69ikOHDoHLHfw/orOzEwsWLMDKlSuxbt06FBcX48UXX8SmTZuQmpqq0/GMHSIKZS9u17SjrLoVxZV3kX+zCTY8LhIjxFg4MxARk10pPAghD6RN3oP9p2/h20t3wOVwMDPSC5HBbggLcIW3O/+BP2NMOkTmz5+PtWvXYuXKlQCAjo4OJCcnY9euXUhISBi07f79+7Ft2zacPXt2IGDS09Nx/fp1fP755zodb7whIleo0NzWjV61FmqNdtB/FUo1OrtV6FT0Qq5QoaNLhca7CtTfVaBN3gM7Gy6CfZ0x1c8ZCRFiRAa7T/hfCoQQolSpkVfciOzCOhRX3kXDXQWETnbw9RRgyUNBeChm+Baesej7uWm0IUFyuRwymQyRkZEDj4lEIgQEBKC4uHhIiJSUlCAiImLQFUpkZCT27dtn8Fo/+OdlXL3ZBKBvqJ2tDXfgv472NhA62ULgZAeBky2cBfYI8XeB2NUJ3m58+HoKwKPQIIQYmIOdDWZFSzArWgKgr9+1rLoNNY2dcBU5GK0Oo4VIZ2cngL7guJdQKBx47v7thULhoMdEItGw2wLAjh078Omnnw55PDQ0dLwlE0IIGYPRQkQgEADouyK5l1wuH3ju/u1bWgbPHdPR0THstgCQlpaGtLS0UWtgu6PdUOi8zAudl3mh8xqd0dpdhEIhfHx8UFhYOPCYXC5HVVUVwsOHLv8aFhaGGzduQKv97w02RUVFCAsLM0q9hBBCxmbUxvsVK1Zg586dqKiogEKhQHp6OgIDAxEXFzdk2wULFkCj0SAjIwMqlQoFBQXYt28fnn76aWOWTAghZBRGDZG1a9di0aJFWLlyJZKTkyGTyZCRkQEul4vLly9DKpWitrYWQF9zVmZmJs6ePYv4+HikpaXh5ZdfxqJFi4xZMiGEkFEYdcImLpeLDRs2YMOGDUOei4+PR35+/qDHIiIi8OWXX07Y8V955ZUJ25cpofMyL3Re5oXOa3RGvU+EEEKIZaEbGgghhIwbhQghhJBxs9gQ+eGHH/D8889jxowZCA0NRU1NzZivWbVqFSIjIyGVSge+srKyjFCtfsZzbq2trXjttdcQGxuLxMRE/OY3v4FKZXpLb/7973/H3LlzER0djRUrVqCkpGTU7efPn4+oqKhBP7NTp04ZqdrhabVabNu2DcnJyZBKpVizZg1kMtmI29+4cQMrVqxAdHQ05s6dq/O0Psam73mFhoZi+vTpg342pna/xdGjR7Fy5UrExsbqdGNydXU11qxZA6lUiuTkZHz00UcmNaNuP33P64HeR4yFys/PZ/bv38+cOnWKCQkJYaqrq8d8zbPPPsts377dCNU9mPGc2+rVq5l169YxbW1tTH19PbNs2TLmd7/7nRGq1d2RI0eYhIQEJj8/n1EqlcyOHTuYWbNmMXK5fMTXzJs3j/n666+NWOXY/vznPzPz5s1jbt++zXR2djLvvvsu89hjjzEajWbItnK5nElKSmJ27NjBKJVKJj8/n0lISGCOHTvGQuWj0+e8GIZhQkJCmOzsbCNXqZ+zZ88yhw8fZvbt28eEhISMuq1arWYWL17MvPvuu0xnZydz+/ZtZt68eUxmZqaRqtWdPufFMA/2PrLYEOlXXV1tcSHST9dz69/u1q1bA4+dPn2aiY6OZpRKpaHL1Nmzzz7LfPDBBwP/1mg0zKxZs5gDBw6M+BpTDJF58+YxWVlZA/9ub29npk2bxuTk5AzZ9uuvv2ZmzZo16IP4gw8+YFatWmWUWvWhz3kxjHmESL/s7OwxP2yzs7OZadOmMe3t7QOPZWVlMfPnzzd0eeOmy3kxzIO9jyy2OWu8du/ejYSEBKSmpmLr1q3o6upiu6QHVlJSAkdHRwQHBw88FhUVhe7ublRUVLBY2WAlJSWDJujkcrmIiIhAcXHxqK9LT09HYmIiHnvsMfz1r39Fb2+voUsd0VgTjd5vpIlGx2rGMzZ9z6vfhg0bMGPGDCxbtgx79+41RqkGU1JSgoCAgEHz/0VGRqKmpmbEOf3MyXjfR2a3sPdbb72FAwcOjPj8woULsX379nHt+5e//CWCgoIgEolw8+ZNvPPOO6ipqcHHH388zmr1Y6hzG24yy/5/G+OXX9fz6uzs1HmCzn6bN29GREQEHBwcUFBQgI0bN6KtrQ0bN26csPr1YeiJRtmi73kBff1bUqkUXC4X2dnZeP3116FWqweWgjA3I/2s+p8baV4/c/Ag7yOzC5H33nsPb7zxxojP29nZjXvfsbGxA9+HhYXhnXfewXPPPQelUgkHB8NPrWyocxMIBEPe6P0TYRrjF1/X8xIIBMNO0Onu7j7iaxMTEwe+j42Nxauvvor09HTWQsTQE42yRd/zAoCkpKSB71NSUvDCCy/gm2++MdsQGe591NHRMfCcOXuQ95HZhQifzwefzzfKsfqbGBgjjb4w1LmFhYVBoVDg9u3bA01ahYWFcHBwwOTJkyf8ePfT9bzCwsJQWFg4sHKlVqvFjRs3sHjxYp2Pdf8KmcZ270SjUVFRAMaeaPTYsWPQarUDtZviRKP6ntdwuFyuSY5k0lVYWBju3LkDuVw+cEVSVFQEX19fsw+R++nzPrLYPhGtVouenp6BYawqlQo9PT3QaDTDbt/c3IwzZ85AoVCAYRjcunUL77//PubPnw9HR0djlj4mfc/N19cXs2fPRnp6Otrb29HY2Ijt27fjJz/5Cezt7Y1Z+qhWrFiBffv2oaCgACqVChkZGQCAhx9+eNjtKysrkZubi56eHmi1WhQUFGD79u149NFHjVn2EJY60ag+51VUVITr169DpVJBrVbjwoUL2LVrF+s/m/tpNBr09PQMtP/39PQM/D7dLz4+Hv7+/khPT4dCoUBFRQUyMzNN8melz3k98PtoXN3xZqB/VML9X/eOQIiJiWEOHTrEMAzD1NTUME888QQTGxvLxMTEMA8//DCzZcuWUYeXskXfc2MYhmlpaWFeffVVRiqVMvHx8cx7771nUiOz+u3atYtJSUlhoqKimJ/+9KdMcXHxwHMymYyJiYlhcnNzGYZhmGvXrjFLlixhYmJiGKlUyqSmpjIZGRmMSqViq3yGYfpGlW3dupWZOXMmEx0dzaxevXpgBF1ubi4TExPDyGSyge2LioqYp556iomKimJSUlKYf/zjH2yVPip9zuvEiRNMamoqExMTw8TFxTFLlixhvvjiCzbLH9bXX3897HspOzt7yO8bwzBMVVUVs3r1aiY6OpqZOXMms23bNkar1bJ4BsPT57we9H1Ec2cRQggZN4ttziKEEGJ4FCKEEELGjUKEEELIuFGIEEIIGTcKEUIIIeNGIUIIIWTcKEQIIYSMG4UIIYSQcaMQIYQQMm7/P7DBLbXZDuozAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "cors_cor = np.array(list(map(lambda x: x[0], cors)))\n",
+    "sns.kdeplot(cors_cor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 73,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.4457697289837318"
+      ]
+     },
+     "execution_count": 73,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.median(cors_cor[~np.isnan(cors_cor)])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Global correlation for imputed ATAC"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0481468739087362"
+      ]
+     },
+     "execution_count": 74,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_global_pearson(adata.layers['X_magic'].toarray(),\n",
+    "                adata.layers['gene_score_cross_magic'].toarray())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "openproblems",
    "language": "python",
-   "name": "python3"
+   "name": "openproblems"
   },
   "language_info": {
    "codemirror_mode": {
@@ -10347,7 +10547,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.8"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
I added the diffusion based atac imputation we talked about to the snare test notebook. I left the knn-based approach in there as a comparison. Since it also uses the neighborhood in RNA-expression space, the results are somewhat similar. In both cases, however, the regularization is quite strong (300 neighbors for the knn and 10 iterations for the diffusion based). It seems the 300 might have been chosen since it works well in the gene based correlations and I tried to produce comparable results with my 10 iterations.

@qinqian Please let me know if there is anything else I can do and thank you for all the organization and preparation!